### PR TITLE
feat: Added VSCode Launch Configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Next.js: debug full stack",
+        "type": "node-terminal",
+        "request": "launch",
+        "command": "npm run dev",
+        "serverReadyAction": {
+          "pattern": "- Local:.+(https?://.+)",
+          "uriFormat": "%s",
+          "action": "openExternally"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
## Description

- Added a launch configuration within VSCode, allowing for developers to run the web server locally (and debug) and opens their default browser to `https://localhost:3000`

## Test Guidelines
- Clone Repository and Checkout Branch
- Open up project in VSCode
- Press `CTRL+Shift+D` or Open Debug Panel from the Left-Hand side menu
- Click the Play Button or press `F5`
- Evaluate if development server is running and your default browser opens up to `https://localhost:3000`