### PR TITLE
Optimized Route Redirection for Auth & Error Toasts

### DIFF
--- a/src/app/(main)/(routes)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(main)/(routes)/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
 import Link from "next/link"
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 import { buttonVariants } from "@/components/ui/button"
 import { UserAuthForm } from "@/components/user-auth-form"
 import { ModeToggle } from "@/components/ui/mode-toggle"

--- a/src/app/(main)/(routes)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(main)/(routes)/sign-up/[[...sign-up]]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
 import Link from "next/link"
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 import { buttonVariants } from "@/components/ui/button"
 import { UserAuthForm } from "@/components/user-auth-form"
 import { ModeToggle } from "@/components/ui/mode-toggle"

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -10,4 +10,5 @@ function handler(req: Request) {
   })
 }
 
+
 export { handler as GET, handler as POST };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,11 +12,7 @@ export const metadata: Metadata = {
   description: 'Built with love by PSH IEEE',
 }
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -10,7 +10,7 @@ import {
   useFormContext,
 } from "react-hook-form"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 import { Label } from "@/components/ui/label"
 
 const Form = FormProvider

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement> { }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
@@ -13,7 +13,7 @@ const labelVariants = cva(
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+  VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -3,7 +3,7 @@ import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/client-utils"
 
 const ToastProvider = ToastPrimitives.Provider
 

--- a/src/components/user-auth-form.tsx
+++ b/src/components/user-auth-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn, toastErrorParams } from "@/lib/client-utils";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useForm } from "react-hook-form";
@@ -12,12 +12,18 @@ import { TUserAuthForm, UserAuthFormSchema } from "@/lib/zod-schemas/user-auth";
 import { trpc } from "@/app/_trpc/client";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 
+
 interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> { }
 
 export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
-  const baseURL = (typeof window !== "undefined") ? window.location.origin : '';
+
+  // Handle stale magic link error from /api/auth/callback redirect
+  // by displaying an error toast if there is an `?error=` as part of the url
+  toastErrorParams();
 
   async function handleSignInWithGoogle() {
+    const baseURL = (typeof window !== "undefined") ? window.location.origin : '';
+
     const supabase = createClientComponentClient();
     await supabase.auth.signInWithOAuth({
       provider: 'google',
@@ -45,7 +51,7 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
       toast({
         variant: "destructive",
         title: "Oops, Something Went Wrong!",
-        description: "If you've encountered an issue, please contact our event administrators for assistance. We apologize for any inconvenience and will resolve it promptly",
+        description: "If you've encountered an issue, please contact our event administrators for assistance. We apologize for any inconvenience and will resolve it promptly.",
         duration: 2000
       })
     }

--- a/src/lib/client-utils.ts
+++ b/src/lib/client-utils.ts
@@ -1,0 +1,24 @@
+import { toast } from "@/components/ui/use-toast";
+import { type ClassValue, clsx } from "clsx"
+import { useSearchParams } from "next/navigation";
+import { twMerge } from "tailwind-merge"
+ 
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+export function toastErrorParams() {
+  const searchParams = useSearchParams();
+  const error_reason = searchParams.get("error");
+
+  if (error_reason) {
+    const error_description = searchParams.get("error_description");
+
+    toast({
+      variant: "destructive",
+      title: error_reason,
+      description: error_description as string,
+      duration: 5000
+    })
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
- 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}


### PR DESCRIPTION
# Description

Whenever a user would attempt to login via a stale (old) magic link, supabase would redirect back to `api/auth/callback` with the following query params: `error`, `error_description`, and `error_code`, which would then redirect to whereever our callback route would redirect them to traditionally and pass these values as part of `window.location.hash`.

Typically, this was to the dashboard under a false assumption of a valid session being provided from supabase on auth code exchange to the user. Implemented logic to pass those parameters via queryParams alongside the hash and created a client-utils helper function to display a toast with the error parsed from URLSearchParams.

## Test Guidelines

* Login via magic email
* Sign out
* Reuse the same magic email link from original email
* Verify if error toast displays