### PR TITLE
RLS to App_Schema Tables and Drizzle Migration Table

### DIFF
--- a/src/db/drizzle/0008_unique_warhawk.sql
+++ b/src/db/drizzle/0008_unique_warhawk.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "app_schema"."app_announcement" ALTER COLUMN "announcement_created_at" SET NOT NULL;
+
+ALTER TABLE "app_schema"."app_announcement" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app_schema"."app_role" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app_schema"."app_school_year" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app_schema"."app_team" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "app_schema"."app_user_profile" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "drizzle"."__drizzle_migrations" ENABLE ROW LEVEL SECURITY;

--- a/src/db/drizzle/meta/0008_snapshot.json
+++ b/src/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,306 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "448e1180-471f-45a8-b2c5-7c27a0edcf47",
+  "prevId": "878869de-af03-4081-b11a-4bd400be844b",
+  "tables": {
+    "app_announcement": {
+      "name": "app_announcement",
+      "schema": "app_schema",
+      "columns": {
+        "announcement_uuid": {
+          "name": "announcement_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "announcement_created_at": {
+          "name": "announcement_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "announcement_author": {
+          "name": "announcement_author",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_content": {
+          "name": "announcement_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_announcement_announcement_author_app_user_profile_user_uuid_fk": {
+          "name": "app_announcement_announcement_author_app_user_profile_user_uuid_fk",
+          "tableFrom": "app_announcement",
+          "tableTo": "app_user_profile",
+          "columnsFrom": [
+            "announcement_author"
+          ],
+          "columnsTo": [
+            "user_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_role": {
+      "name": "app_role",
+      "schema": "app_schema",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_role_role_name_unique": {
+          "name": "app_role_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_name"
+          ]
+        }
+      }
+    },
+    "app_school_year": {
+      "name": "app_school_year",
+      "schema": "app_schema",
+      "columns": {
+        "school_year_id": {
+          "name": "school_year_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "school_year_name": {
+          "name": "school_year_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_school_year_school_year_name_unique": {
+          "name": "app_school_year_school_year_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_year_name"
+          ]
+        }
+      }
+    },
+    "app_team": {
+      "name": "app_team",
+      "schema": "app_schema",
+      "columns": {
+        "team_uuid": {
+          "name": "team_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_code": {
+          "name": "team_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_points": {
+          "name": "team_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_team_team_name_unique": {
+          "name": "app_team_team_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_name"
+          ]
+        },
+        "app_team_team_code_unique": {
+          "name": "app_team_team_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_code"
+          ]
+        }
+      }
+    },
+    "app_user_profile": {
+      "name": "app_user_profile",
+      "schema": "app_schema",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_email_address": {
+          "name": "user_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_avatar_url": {
+          "name": "user_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_onboarding_complete": {
+          "name": "user_onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_display_name": {
+          "name": "user_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_resume_url": {
+          "name": "user_resume_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_team_uuid": {
+          "name": "user_team_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_school_year": {
+          "name": "user_school_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        }
+      },
+      "indexes": {
+        "user_uuid_index": {
+          "name": "user_uuid_index",
+          "columns": [
+            "user_uuid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "app_user_profile_user_team_uuid_app_team_team_uuid_fk": {
+          "name": "app_user_profile_user_team_uuid_app_team_team_uuid_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_team",
+          "columnsFrom": [
+            "user_team_uuid"
+          ],
+          "columnsTo": [
+            "team_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_school_year_app_school_year_school_year_name_fk": {
+          "name": "app_user_profile_user_school_year_app_school_year_school_year_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_school_year",
+          "columnsFrom": [
+            "user_school_year"
+          ],
+          "columnsTo": [
+            "school_year_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_role_app_role_role_name_fk": {
+          "name": "app_user_profile_user_role_app_role_role_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_role",
+          "columnsFrom": [
+            "user_role"
+          ],
+          "columnsTo": [
+            "role_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_user_profile_user_email_address_unique": {
+          "name": "app_user_profile_user_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_email_address"
+          ]
+        },
+        "app_user_profile_user_display_name_unique": {
+          "name": "app_user_profile_user_display_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_display_name"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app_schema": "app_schema"
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1698890488825,
       "tag": "0007_clumsy_thunderbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1698906386538,
+      "tag": "0008_unique_warhawk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/drizzle/schema.ts
+++ b/src/db/drizzle/schema.ts
@@ -60,7 +60,9 @@ export const app_announcement = app_schema.table("app_announcement", {
   announcement_uuid: uuid("announcement_uuid")
     .primaryKey()
     .default(sql`uuid_generate_v4()`),
-  announcement_created_at: timestamp("announcement_created_at").defaultNow(),
+  announcement_created_at: timestamp("announcement_created_at")
+    .notNull()
+    .defaultNow(),
   announcement_author: uuid("announcement_author")
     .notNull()
     .references(() => app_user_profile.user_uuid),


### PR DESCRIPTION
# Description
I added the notNull() property to announcement_created_at. I then generated the SQL script to migrate this change, but added Row Level Security (RLS) to all tables in app_schema and __drizzle_migrations.

# Test Guidelines
1. Run `pnpm generate` to generate SQL scripts.
2. Run `pnpm migrate` to migrate these scripts into your local Supabase instance.
3. Go to your [local Supabase instance](http://localhost:54323/project/default/auth/policies).
4. Check if the relevant tables have RLS.

If you run into migration problems, delete the app_schema and drizzle schemas.