### PR TITLE
Added Major Table and Support to Profile

### DIFF
--- a/src/db/drizzle/0011_red_romulus.sql
+++ b/src/db/drizzle/0011_red_romulus.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "app_schema"."app_major" (
+	"major_id" serial PRIMARY KEY NOT NULL,
+	"major_name" text NOT NULL,
+	CONSTRAINT "app_major_major_name_unique" UNIQUE("major_name")
+);
+--> statement-breakpoint
+ALTER TABLE "app_schema"."app_user_profile" ADD COLUMN "user_major" text;--> statement-breakpoint
+ALTER TABLE "app_schema"."app_user_profile" ADD COLUMN "user_support_administrative" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "app_schema"."app_user_profile" ADD COLUMN "user_support_technical" boolean DEFAULT false;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "app_schema"."app_user_profile" ADD CONSTRAINT "app_user_profile_user_major_app_major_major_name_fk" FOREIGN KEY ("user_major") REFERENCES "app_schema"."app_major"("major_name") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/src/db/drizzle/meta/0011_snapshot.json
+++ b/src/db/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,375 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "e3f62582-ba6c-4fc9-8c14-48bb851b120b",
+  "prevId": "8730e109-e681-4c76-8c2f-4106040c1a8a",
+  "tables": {
+    "app_announcement": {
+      "name": "app_announcement",
+      "schema": "app_schema",
+      "columns": {
+        "announcement_uuid": {
+          "name": "announcement_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "announcement_created_at": {
+          "name": "announcement_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "announcement_author_uuid": {
+          "name": "announcement_author_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_title": {
+          "name": "announcement_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_content": {
+          "name": "announcement_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_announcement_announcement_author_uuid_app_user_profile_user_uuid_fk": {
+          "name": "app_announcement_announcement_author_uuid_app_user_profile_user_uuid_fk",
+          "tableFrom": "app_announcement",
+          "tableTo": "app_user_profile",
+          "columnsFrom": [
+            "announcement_author_uuid"
+          ],
+          "columnsTo": [
+            "user_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_major": {
+      "name": "app_major",
+      "schema": "app_schema",
+      "columns": {
+        "major_id": {
+          "name": "major_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "major_name": {
+          "name": "major_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_major_major_name_unique": {
+          "name": "app_major_major_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "major_name"
+          ]
+        }
+      }
+    },
+    "app_role": {
+      "name": "app_role",
+      "schema": "app_schema",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_role_role_name_unique": {
+          "name": "app_role_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_name"
+          ]
+        }
+      }
+    },
+    "app_school_year": {
+      "name": "app_school_year",
+      "schema": "app_schema",
+      "columns": {
+        "school_year_id": {
+          "name": "school_year_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "school_year_name": {
+          "name": "school_year_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_school_year_school_year_name_unique": {
+          "name": "app_school_year_school_year_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_year_name"
+          ]
+        }
+      }
+    },
+    "app_team": {
+      "name": "app_team",
+      "schema": "app_schema",
+      "columns": {
+        "team_uuid": {
+          "name": "team_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_code": {
+          "name": "team_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_points": {
+          "name": "team_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_team_team_name_unique": {
+          "name": "app_team_team_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_name"
+          ]
+        },
+        "app_team_team_code_unique": {
+          "name": "app_team_team_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_code"
+          ]
+        }
+      }
+    },
+    "app_user_profile": {
+      "name": "app_user_profile",
+      "schema": "app_schema",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_email_address": {
+          "name": "user_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_avatar_url": {
+          "name": "user_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_onboarding_complete": {
+          "name": "user_onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_display_name": {
+          "name": "user_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_resume_url": {
+          "name": "user_resume_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_team_uuid": {
+          "name": "user_team_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_school_year": {
+          "name": "user_school_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_major": {
+          "name": "user_major",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "user_support_administrative": {
+          "name": "user_support_administrative",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_support_technical": {
+          "name": "user_support_technical",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_uuid_index": {
+          "name": "user_uuid_index",
+          "columns": [
+            "user_uuid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "app_user_profile_user_team_uuid_app_team_team_uuid_fk": {
+          "name": "app_user_profile_user_team_uuid_app_team_team_uuid_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_team",
+          "columnsFrom": [
+            "user_team_uuid"
+          ],
+          "columnsTo": [
+            "team_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_school_year_app_school_year_school_year_name_fk": {
+          "name": "app_user_profile_user_school_year_app_school_year_school_year_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_school_year",
+          "columnsFrom": [
+            "user_school_year"
+          ],
+          "columnsTo": [
+            "school_year_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_major_app_major_major_name_fk": {
+          "name": "app_user_profile_user_major_app_major_major_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_major",
+          "columnsFrom": [
+            "user_major"
+          ],
+          "columnsTo": [
+            "major_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_role_app_role_role_name_fk": {
+          "name": "app_user_profile_user_role_app_role_role_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_role",
+          "columnsFrom": [
+            "user_role"
+          ],
+          "columnsTo": [
+            "role_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_user_profile_user_email_address_unique": {
+          "name": "app_user_profile_user_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_email_address"
+          ]
+        },
+        "app_user_profile_user_display_name_unique": {
+          "name": "app_user_profile_user_display_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_display_name"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app_schema": "app_schema"
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1698953630818,
       "tag": "0010_striped_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "5",
+      "when": 1698959412152,
+      "tag": "0011_red_romulus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/drizzle/migrate.ts
+++ b/src/db/drizzle/migrate.ts
@@ -63,6 +63,181 @@ migrate(db, { migrationsFolder: "src/db/drizzle" })
       .values({ school_year_name: "post_graduate" })
       .onConflictDoNothing();
 
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "non_applicable" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "undecided" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "accounting" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "american_studies" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "biobehavioral_health" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "biology" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "civil_engineering" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "communication_sciences_and_disorders" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "communications" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "computer_science" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "criminal_justice" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "cybersecurity_analytics_and_operations" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "electrical_engineering" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "electrical_engineering_technology" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "elementary_education" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "english" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "enterprise_technology_integration" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "finance" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "health_policy_and_administration" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "human_capital_management" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "human_development_and_family_studies" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "human-centered_design_and_development" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "humanities" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "information_sciences_and_technology" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "information_systems" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "kinesiology" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "management" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "marketing" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "mathematical_sciences" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "mechanical_engineering" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "mechanical_engineering_technology" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "nursing_(second_degree)" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "political_science" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "project_and_supply_chain_management" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "psychology" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "public_policy" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "science" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "secondary_education_english" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "secondary_education_mathematics" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "secondary_education_social_studies" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "security_and_risk_analysis" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({ major_name: "sociology" })
+      .onConflictDoNothing();
+    await db
+      .insert(schema.app_major)
+      .values({
+        major_name: "structural_design_&_construction_engineering_technology",
+      })
+      .onConflictDoNothing();
+
     await pool.end();
   })
   .catch(async (err) => {

--- a/src/db/drizzle/schema.ts
+++ b/src/db/drizzle/schema.ts
@@ -25,10 +25,15 @@ export const app_user_profile = app_schema.table(
     user_school_year: text("user_school_year").references(
       () => app_school_year.school_year_name,
     ),
+    user_major: text("user_major").references(() => app_major.major_name),
     user_role: text("user_role")
       .notNull()
       .references(() => app_role.role_name)
       .default("participant"),
+    user_support_administrative: boolean("user_support_administrative").default(
+      false,
+    ),
+    user_support_technical: boolean("user_support_technical").default(false),
   },
   (table) => {
     return {
@@ -40,6 +45,11 @@ export const app_user_profile = app_schema.table(
 export const app_role = app_schema.table("app_role", {
   role_id: serial("role_id").primaryKey(),
   role_name: text("role_name").unique().notNull(),
+});
+
+export const app_major = app_schema.table("app_major", {
+  major_id: serial("major_id").primaryKey(),
+  major_name: text("major_name").unique().notNull(),
 });
 
 export const app_school_year = app_schema.table("app_school_year", {


### PR DESCRIPTION
# Description
I added all majors in migrate.ts which should populate the app_major table. I also added user_support_administrative and user_support_technical as boolean values in the app_user_profile table,

# Test Guidelines
1. Delete app_schema from Supabase
2. Delete drizzle from Supabase
3. Run `pnpm generate`
4. Run `pnpm migrate`
5. Check if app_major table is created.
6. Check if support boolean values are added to app_user_profile.