### PR TITLE
Stabilize announcements

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "latest",
     "react-dom": "latest",
     "react-hook-form": "^7.47.0",
+    "superjson": "^2.2.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ dependencies:
   react-hook-form:
     specifier: ^7.47.0
     version: 7.47.0(react@18.2.0)
+  superjson:
+    specifier: ^2.2.0
+    version: 2.2.0
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -1974,6 +1977,13 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.16
+    dev: false
+
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -3142,6 +3152,11 @@ packages:
       get-intrinsic: 1.2.1
     dev: true
 
+  /is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+    dev: false
+
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
@@ -4199,6 +4214,13 @@ packages:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
+
+  /superjson@2.2.0:
+    resolution: {integrity: sha512-vSr6kwT/LY3T1+JaZllIGFp5+qEYyCw/s6EMgR8TulTwRbKETuVIqN4RTurPBTU/HlEpP0ytN3srB2vjjeBRoQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      copy-anything: 3.0.5
+    dev: false
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}

--- a/src/app/(main)/(routes)/about/page.tsx
+++ b/src/app/(main)/(routes)/about/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
   description: "Learn what HackPSH Is about!",
 }
 
-export default function AboutPage() {
+export default function Page() {
   return (
     <div>
       <PublicSiteHeader />

--- a/src/app/(main)/(routes)/announcements/create-post/page.tsx
+++ b/src/app/(main)/(routes)/announcements/create-post/page.tsx
@@ -11,8 +11,8 @@ export default function CreateAnnouncementPage() {
   return (
     <>
       <ProtectedSiteHeader />
-      <h1 className="m-10 text-3xl font-bold text-center">Create an Announcement</h1>
-      <div className="mt-10 flex-1 justify-center w-[40rem]">
+      <div className="container relative flex-col items-center justify-center space-y-6">
+        <h1 className="mt-10 text-3xl font-bold">Create Announcement</h1>
         <CreateAnnouncementPostForm />
       </div>
     </>

--- a/src/app/(main)/(routes)/announcements/create-post/page.tsx
+++ b/src/app/(main)/(routes)/announcements/create-post/page.tsx
@@ -1,5 +1,11 @@
 import ProtectedSiteHeader from "@/app/_components/nav/protected-site-header";
 import { CreateAnnouncementPostForm } from "@/app/_components/forms/create-announcement-post-form";
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Create Announcement | HackPSH",
+  description: "Create an announcement for everyone at the event.",
+};
 
 export default function CreateAnnouncementPage() {
   return (

--- a/src/app/(main)/(routes)/announcements/page.tsx
+++ b/src/app/(main)/(routes)/announcements/page.tsx
@@ -12,10 +12,15 @@ export const metadata: Metadata = {
 
 export default function AnnouncementsPage() {
   return (
-    <div>
-      <ProtectedSiteHeader />
-      <p className="m-10 text-center text-3xl font-bold">Announcements</p>
-      <Announcements />
-    </div>
+    <>
+      <div>
+        <ProtectedSiteHeader />
+      </div>
+      <div className="container relative flex-col items-center justify-center">
+        <p className="m-10 text-3xl font-bold text-center">Announcements</p>
+        <Announcements />
+      </div>
+    </>
+
   );
 }

--- a/src/app/(main)/(routes)/announcements/page.tsx
+++ b/src/app/(main)/(routes)/announcements/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   description: "Catch the latest updates within the competition!",
 };
 
-export default async function AnnouncementsPage() {
+export default function AnnouncementsPage() {
   return (
     <div>
       <ProtectedSiteHeader />

--- a/src/app/(main)/(routes)/announcements/page.tsx
+++ b/src/app/(main)/(routes)/announcements/page.tsx
@@ -1,6 +1,7 @@
 import ProtectedSiteHeader from "@/app/_components/nav/protected-site-header";
 import { type Metadata } from "next";
 import { Announcements } from "@/app/_components/announcement/announcements";
+import { AdminCreatePostLink } from "@/app/_components/announcement/admin-create-post-link";
 
 export const revalidate = 0;
 export const dynamic = "force-dynamic";
@@ -18,6 +19,7 @@ export default function AnnouncementsPage() {
       </div>
       <div className="container relative flex-col items-center justify-center">
         <p className="m-10 text-3xl font-bold text-center">Announcements</p>
+        <AdminCreatePostLink className="mb-4" />
         <Announcements />
       </div>
     </>

--- a/src/app/(main)/(routes)/announcements/page.tsx
+++ b/src/app/(main)/(routes)/announcements/page.tsx
@@ -21,6 +21,5 @@ export default function AnnouncementsPage() {
         <Announcements />
       </div>
     </>
-
   );
 }

--- a/src/app/(main)/(routes)/leaderboard/page.tsx
+++ b/src/app/(main)/(routes)/leaderboard/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   description: "See where your team stands amongst the competition.",
 }
 
-export default async function LeaderboardPage() {
+export default function LeaderboardPage() {
   return (
     <div>
       <ProtectedSiteHeader />

--- a/src/app/_components/announcement/admin-create-post-link.tsx
+++ b/src/app/_components/announcement/admin-create-post-link.tsx
@@ -1,0 +1,31 @@
+import { siteConfig } from "@/app/_config/site";
+import { cn } from "@/app/_lib/client-utils";
+import { serverTRPC } from "@/app/_trpc/server";
+import { composeServerComponentClient } from "@/server/lib/supabase/server";
+import { getUser } from "@/shared/supabase/auth";
+import { Button } from "../ui/button";
+import Link from "next/link";
+
+type AdminCreatePostLinkProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export async function AdminCreatePostLink({ className }: AdminCreatePostLinkProps) {
+  const supabase = composeServerComponentClient();
+  try {
+    const user = await getUser(supabase);
+    const { get_user_role } = await serverTRPC.user.get_user_role.query({
+      user_uuid: user.id
+    });
+
+    if (get_user_role === "admin") {
+      return (
+        <Button className={cn("h-8 mr-4 font-semibold", className)} suppressHydrationWarning asChild>
+          <Link href={siteConfig.paths.create_post} scroll={false}>
+            <span>Create Post</span>
+          </Link>
+        </Button>
+      )
+    }
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/src/app/_components/announcement/announcement-post.tsx
+++ b/src/app/_components/announcement/announcement-post.tsx
@@ -8,15 +8,34 @@ interface AnnouncementPostProps {
 export function AnnouncementPost({ postData }: AnnouncementPostProps) {
   const {
     announcement_uuid,
+    announcement_created_at,
+    announcement_author_display_name,
     announcement_title,
     announcement_content,
   } = postData;
 
+  const format_time_options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  };
+
+  const formatted_announcement_created_at = Intl.DateTimeFormat('en-US', format_time_options).format(announcement_created_at);
   return (
     <Card key={announcement_uuid}>
       <CardHeader>
         <CardTitle>{announcement_title}</CardTitle>
-        <CardDescription>Description</CardDescription>
+        <CardDescription>
+          <div>
+            <span className="font-semibold">Created By: </span>
+            {announcement_author_display_name!}
+            {" | "}
+            <span className="font-semibold">Posted On: </span>
+            {formatted_announcement_created_at}
+          </div>
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <p>{announcement_content}</p>

--- a/src/app/_components/announcement/announcement-post.tsx
+++ b/src/app/_components/announcement/announcement-post.tsx
@@ -28,13 +28,11 @@ export function AnnouncementPost({ postData }: AnnouncementPostProps) {
       <CardHeader>
         <CardTitle>{announcement_title}</CardTitle>
         <CardDescription>
-          <div>
-            <span className="font-semibold">Created By: </span>
-            {announcement_author_display_name!}
-            {" | "}
-            <span className="font-semibold">Posted On: </span>
-            {formatted_announcement_created_at}
-          </div>
+          <span className="font-semibold">Created By: </span>
+          {announcement_author_display_name!}
+          {" | "}
+          <span className="font-semibold">Posted On: </span>
+          {formatted_announcement_created_at}
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/src/app/_components/announcement/announcement-post.tsx
+++ b/src/app/_components/announcement/announcement-post.tsx
@@ -1,4 +1,4 @@
-import { AnnouncementPost } from "@/server/dao/announcements";
+import { type AnnouncementPost } from "@/server/dao/announcements";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "../ui/card";
 
 interface AnnouncementPostProps {

--- a/src/app/_components/announcement/announcements.tsx
+++ b/src/app/_components/announcement/announcements.tsx
@@ -12,7 +12,5 @@ export async function Announcements() {
       />
   );
 
-  return (
-    <div>{postElements}</div>
-  )
+  return (<div className="space-y-6">{postElements}</div>);
 }

--- a/src/app/_components/announcement/announcements.tsx
+++ b/src/app/_components/announcement/announcements.tsx
@@ -1,18 +1,18 @@
 import { serverTRPC } from "@/app/_trpc/server";
-// import { AnnouncementPost } from "./announcement-post";
+import { AnnouncementPost } from "./announcement-post";
 
 export async function Announcements() {
   const serverAnnouncementPosts = await serverTRPC.announcements.get_announcement_posts.query();
 
-  // const postElements = serverAnnouncementPosts.map(
-  //   announcementPostData =>
-  //     <AnnouncementPost
-  //       key={announcementPostData.announcement_uuid}
-  //       postData={announcementPostData}
-  //     />
-  // );
+  const postElements = serverAnnouncementPosts.map(
+    announcementPostData =>
+      <AnnouncementPost
+        key={announcementPostData.announcement_uuid}
+        postData={announcementPostData}
+      />
+  );
 
   return (
-    <p>{JSON.stringify(serverAnnouncementPosts)}</p>
+    <div>{postElements}</div>
   )
 }

--- a/src/app/_components/forms/create-announcement-post-form.tsx
+++ b/src/app/_components/forms/create-announcement-post-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getUser } from "@/app/_lib/supabase/client";
+import { getUser } from "@/shared/supabase/auth";
 import { type TCreateAnnouncementForm, CreateAnnouncementFormSchema } from "@/app/_lib/zod-schemas/forms/announcements";
 import { trpc } from "@/app/_trpc/react";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/app/_components/forms/create-announcement-post-form.tsx
+++ b/src/app/_components/forms/create-announcement-post-form.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { getUser } from "@/app/_lib/supabase/client";
-import { TCreateAnnouncementForm, CreateAnnouncementFormSchema } from "@/app/_lib/zod-schemas/forms/announcements";
+import { type TCreateAnnouncementForm, CreateAnnouncementFormSchema } from "@/app/_lib/zod-schemas/forms/announcements";
 import { trpc } from "@/app/_trpc/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Button } from "../ui/button";
-import { Form, FormLabel, FormField, FormItem, FormControl, FormMessage, FormDescription } from "../ui/form";
+import { Form, FormLabel, FormField, FormItem, FormControl, FormMessage } from "../ui/form";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
 import { toast } from "../ui/use-toast";

--- a/src/app/_components/leaderboard/realtime-leaderboard.tsx
+++ b/src/app/_components/leaderboard/realtime-leaderboard.tsx
@@ -2,9 +2,6 @@
 
 import { type LeaderboardStandings } from "@/server/dao/leaderboard";
 import DataTable from "./data-table";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { useEffect } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export default function RealtimeLeaderboard({
   serverData,

--- a/src/app/_components/ui/textarea.tsx
+++ b/src/app/_components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/app/_lib/client-utils";
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/app/_config/site.ts
+++ b/src/app/_config/site.ts
@@ -17,6 +17,7 @@ export const siteConfig = {
     leaderboard: "/leaderboard",
     announcements: "/announcements",
     challenges: "/challenges",
+    create_post: "/announcements/create-post",
   },
 };
 

--- a/src/app/_lib/supabase/client.ts
+++ b/src/app/_lib/supabase/client.ts
@@ -1,4 +1,4 @@
-import { SupabaseClient } from "@supabase/auth-helpers-nextjs";
+import { type SupabaseClient } from "@supabase/auth-helpers-nextjs";
 
 export async function getUser(supabase: SupabaseClient) {
   const {

--- a/src/app/_trpc/react.tsx
+++ b/src/app/_trpc/react.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 
 import { type AppRouter } from "@/server/root";
 import { httpBatchLink } from "@trpc/client";
+import { transformer } from "./shared";
 
 export const trpc = createTRPCReact<AppRouter>();
 
@@ -13,6 +14,7 @@ export default function ReactQueryProvider({ children, headers }: { children: Re
   const [queryClient] = useState(() => new QueryClient({}));
   const [trpcClient] = useState(() =>
     trpc.createClient({
+      transformer,
       links: [
         httpBatchLink({
           url: `/api/trpc`,

--- a/src/app/_trpc/server.ts
+++ b/src/app/_trpc/server.ts
@@ -1,9 +1,10 @@
 import { type AppRouter } from "@/server/root";
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import { headers } from "next/headers";
-import { getURL } from "./shared";
+import { getURL, transformer } from "./shared";
 
 export const serverTRPC = createTRPCProxyClient<AppRouter>({
+  transformer,
   links: [
     httpBatchLink({
       url: getURL(),

--- a/src/app/_trpc/shared.ts
+++ b/src/app/_trpc/shared.ts
@@ -1,5 +1,8 @@
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { type AppRouter } from "@/server/root";
+import superjson from "superjson";
+
+export const transformer = superjson;
 
 function getBaseURL() {
   if (typeof window !== "undefined") return "";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,6 +34,8 @@ export async function middleware(req: NextRequest) {
       return redirectToPath(req, siteConfig.paths.onboarding);
     }
 
+    // TODO: Create external functions for handling protected pages & role-based pages
+
     return res;
   } catch (cause) {
     return handleError(req, cause);

--- a/src/server/dao/announcements.ts
+++ b/src/server/dao/announcements.ts
@@ -1,10 +1,27 @@
 import { type Database } from "@/db/drizzle";
-import { app_announcement } from "@/db/drizzle/schema";
+import { app_announcement, app_user_profile } from "@/db/drizzle/schema";
 import { TRPCError } from "@trpc/server";
+import { desc, eq } from "drizzle-orm";
 
 export async function getAnnouncements(db: Database) {
   try {
-    const announcement_posts = await db.select().from(app_announcement);
+    const announcement_posts = await db
+      .select({
+        announcement_uuid: app_announcement.announcement_uuid,
+        announcement_created_at: app_announcement.announcement_created_at,
+        announcement_author_display_name: app_user_profile.user_display_name,
+        announcement_title: app_announcement.announcement_title,
+        announcement_content: app_announcement.announcement_content,
+      })
+      .from(app_announcement)
+      .innerJoin(
+        app_user_profile,
+        eq(
+          app_announcement.announcement_author_uuid,
+          app_user_profile.user_uuid,
+        ),
+      )
+      .orderBy(desc(app_announcement.announcement_created_at));
 
     return announcement_posts;
   } catch (error) {

--- a/src/server/lib/auth/server.ts
+++ b/src/server/lib/auth/server.ts
@@ -1,4 +1,4 @@
-import { BaseError } from "../server-utils";
+import { BaseError } from "@/shared/error";
 
 /**
  * Retrieve Callback Token `code` from PKCE Auth Flow from URL parameters

--- a/src/server/lib/server-utils.ts
+++ b/src/server/lib/server-utils.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { siteConfig } from "../../app/_config/site";
+import { type BaseError } from "@/shared/error";
 
 export function redirectToPath(req: NextRequest, path: string) {
   const redirectUrl = new URL(req.nextUrl.origin);
@@ -22,17 +23,4 @@ export function redirectToSignInWithError(req: NextRequest, error: BaseError) {
   }
 
   return NextResponse.redirect(redirectURLErrorParams);
-}
-
-export class BaseError {
-  public readonly title: string;
-  public readonly description?: string | null;
-
-  constructor(opts: { error_title: string; error_desc: string | null }) {
-    this.title = opts.error_title;
-    this.description = "Something unexpected has occurred.";
-    if (opts.error_desc) {
-      this.description = opts.error_desc;
-    }
-  }
 }

--- a/src/server/lib/server/handleError.ts
+++ b/src/server/lib/server/handleError.ts
@@ -1,7 +1,8 @@
 import { TRPCError } from "@trpc/server";
 import { type NextRequest } from "next/server";
 import { siteConfig } from "@/app/_config/site";
-import { BaseError, redirectToSignInWithError } from "../server-utils";
+import { redirectToSignInWithError } from "../server-utils";
+import { BaseError } from "@/shared/error";
 
 export default function handleError(req: NextRequest, cause: unknown) {
   // Ignore Errors Coming From Sign-In to prevent Infinite Redirect

--- a/src/server/lib/supabase/server.ts
+++ b/src/server/lib/supabase/server.ts
@@ -1,15 +1,22 @@
+import { BaseError } from "@/shared/error";
 import {
   type SupabaseClient,
   createMiddlewareClient,
   createRouteHandlerClient,
+  createServerComponentClient,
 } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 import { type NextRequest, type NextResponse } from "next/server";
-import { BaseError } from "../server-utils";
 
 export function composeRouteHandlerClient() {
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+  return supabase;
+}
+
+export function composeServerComponentClient() {
+  const cookieStore = cookies();
+  const supabase = createServerComponentClient({ cookies: () => cookieStore });
   return supabase;
 }
 

--- a/src/server/procedures/protected/onboarding/updatePersonalDetailsProcedure.ts
+++ b/src/server/procedures/protected/onboarding/updatePersonalDetailsProcedure.ts
@@ -1,6 +1,5 @@
 import { protectedProcedure } from "@/server/trpc";
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export default protectedProcedure.mutation(async ({ ctx, input }) => {
-  return;
+export default protectedProcedure.mutation(() => {
+  return true;
 });

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -1,5 +1,6 @@
 import { TRPCError, initTRPC } from "@trpc/server";
 import { type createTRPCContext } from "./context";
+import superjson from "superjson";
 import { ZodError } from "zod";
 
 /**
@@ -10,6 +11,7 @@ import { ZodError } from "zod";
  * errors on the backend.
  */
 const t = initTRPC.context<typeof createTRPCContext>().create({
+  transformer: superjson,
   errorFormatter({ shape, error }) {
     return {
       ...shape,

--- a/src/shared/error.ts
+++ b/src/shared/error.ts
@@ -1,0 +1,12 @@
+export class BaseError {
+  public readonly title: string;
+  public readonly description?: string | null;
+
+  constructor(opts: { error_title: string; error_desc: string | null }) {
+    this.title = opts.error_title;
+    this.description = "Something unexpected has occurred.";
+    if (opts.error_desc) {
+      this.description = opts.error_desc;
+    }
+  }
+}

--- a/src/shared/supabase/auth.ts
+++ b/src/shared/supabase/auth.ts
@@ -1,3 +1,4 @@
+import { BaseError } from "@/shared/error";
 import { type SupabaseClient } from "@supabase/auth-helpers-nextjs";
 
 export async function getUser(supabase: SupabaseClient) {
@@ -6,8 +7,12 @@ export async function getUser(supabase: SupabaseClient) {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    throw new Error("User cannot be retrieved from current session.");
+    throw new BaseError({
+      error_title: "Authentication Server Error",
+      error_desc: "Cannot retrieve user information at this time.",
+    });
   }
+
   return user;
 }
 
@@ -17,7 +22,10 @@ export async function getSession(supabase: SupabaseClient) {
   } = await supabase.auth.getSession();
 
   if (!session) {
-    throw new Error("Session cannot be found.");
+    throw new BaseError({
+      error_title: "Authentication Server Error",
+      error_desc: "Cannot retrieve user session at this time.",
+    });
   }
 
   return session;


### PR DESCRIPTION
# Description

This continues our work from #42 

* As we had date objects being transferred in JSON (mutate and query) for announcements, we want to serialize these dates properly across the server & client, and so I introduced superjson to handle this via tRPC properly as the integration was quite smooth. 

* Consolidated Supabase auth accessor methods into shared folder
* Consolidated BaseError into shared folder (Can create this BaseError Object Client/Server side and handle with their own respective handler functions)

Adjusted the CSS to be a bit more mobile friendly, dynamic SSR page generation with link to /create-post for admins.
Only admins can create posts and post creation is now fully dynamic.

# Testing Guidelines

* Set your user to admin and attempt to create a post via /announcements/create-post
* Set your user to participant and attempt the same and ensure there is an error being shown
* Travel to announcements page to evaluate results

TODO: Middleware needs to redirect users attempting to use create-post based on their get_user_role (needs to be admin)
