### PR TITLE
Automate startup commands in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,18 @@
 {
-    "image":"mcr.microsoft.com/devcontainers/universal:2",
-    "customizations": {
-        "vscode": {
-          "extensions": [        
-            "eamodio.gitlens",
-            "bradlc.vscode-tailwindcss",
-            "dbaeumer.vscode-eslint",
-            "esbenp.prettier-vscode"
-        ]
-        }
-    },
-    "features": {
-        "ghcr.io/devcontainers-contrib/features/supabase-cli:1": {}
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "eamodio.gitlens",
+        "bradlc.vscode-tailwindcss",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
     }
+  },
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/supabase-cli:1": {}
+  },
+  "postCreateCommand": ["pmpm i", "pnpm migrate"],
+  "postStartCommand": "pnpm run dev"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,8 @@
   "features": {
     "ghcr.io/devcontainers-contrib/features/supabase-cli:1": {}
   },
-  //run when container is created
-  "postCreateCommand": ["pmpm i", "pnpm migrate"],
-  //run when container starts; currently in testing
-  "postStartCommand": ["supabase start", "pnpm run dev"]
+  //install dependencies and migrate sql scripts on container creation
+  "postCreateCommand": "pnpm i && pnpm migrate",
+  //start supabase in background on container start
+  "postStartCommand": "nohup bash -c 'supabase start &'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,6 @@
   "features": {
     "ghcr.io/devcontainers-contrib/features/supabase-cli:1": {}
   },
-  //install dependencies and migrate sql scripts on container creation
-  "postCreateCommand": "pnpm i && pnpm migrate",
-  //start supabase in background on container start
-  "postStartCommand": "nohup bash -c 'supabase start &'"
+  //install dependencies after container creation
+  "postCreateCommand": "pnpm i"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,8 @@
   "features": {
     "ghcr.io/devcontainers-contrib/features/supabase-cli:1": {}
   },
+  //run when container is created
   "postCreateCommand": ["pmpm i", "pnpm migrate"],
-  "postStartCommand": "pnpm run dev"
+  //run when container starts; currently in testing
+  "postStartCommand": ["supabase start", "pnpm run dev"]
 }

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -28,5 +28,30 @@ namespace NodeJS {
      * @type {string}
      */
     VERCEL_URL: string;
+
+    /**
+     *
+     *
+     *
+     */
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: string;
+    /**
+     *
+     *
+     *
+     */
+    NEXT_PUBLIC_SUPABASE_URL: string;
+    /**
+     *
+     *
+     *
+     */
+    SUPABASE_AUTH_EXTERNAL_GOOGLE_OAUTH_CLIENT_ID: string;
+    /**
+     *
+     *
+     *
+     */
+    SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: string;
   }
 }

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -2,8 +2,6 @@
 namespace NodeJS {
   interface ProcessEnv {
     /**
-     * Make sure to run `pnpm run introspect` to pull table schema and all types.
-     *
      * We utilize Drizzle ORM for this project for type-safety and SQL Migrations
      * and to access the DB.
      *
@@ -30,28 +28,28 @@ namespace NodeJS {
     VERCEL_URL: string;
 
     /**
+     * JWT (JSON Web Token) used to interact with the database if the user is not logged
+     * in (anonymous). This key is meant to have limited privilegeswhich can be defined
+     * using RLS (Row Level Security) policies.
      *
-     *
-     *
+     * See Docs for more about RLS policies:
+     * https://supabase.com/docs/guides/auth/row-level-security
+     * @type {string}
      */
     NEXT_PUBLIC_SUPABASE_ANON_KEY: string;
+
     /**
+     * URL for Supabase API.
      *
-     *
-     *
+     * @type {string}
      */
     NEXT_PUBLIC_SUPABASE_URL: string;
+
     /**
-     *
-     *
-     *
+     * Credentials used to allow access to Google OAuth services.
+     * @type {string}
      */
     SUPABASE_AUTH_EXTERNAL_GOOGLE_OAUTH_CLIENT_ID: string;
-    /**
-     *
-     *
-     *
-     */
     SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: string;
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generate": "drizzle-kit generate:pg",
     "drop_migrations": "drizzle-kit drop",
     "db_push": "drizzle-kit push:pg",
-    "migrate": "pnpm dlx esno src/db/drizzle/migrate.ts"
+    "migrate": "pnpm dlx esno src/db/drizzle/migrate.ts",
+    "setup": "supabase start && pnpm migrate && pnpm run dev"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.1",


### PR DESCRIPTION
# Description
- Automatically install dependenies with postCreateCommand.
- Added script `pnpm run setup` to start supabase, migrate SQL, and run project.
- Added comments to _environment.d.ts_.

# Test Guidelines
1. Create a codespace from the repository. This will load up VSCode through the browser to initially build it.
2. After it finishes building, end the browser codespace.
3. Launch that codespace locally in the VSCode application.
4. Run `pnpm run setup`.

# Notes
I did not use tasks to run the several necessary setup commands, but instead did so in a single script as mentioned before. This allows users to setup the project in one step. I also have abstract comments on some environment variables that need to be understood and updated accordingly.