### PR TITLE
Fix Onboarding Redirects

### DIFF
--- a/src/app/_components/onboarding/create-team-form.tsx
+++ b/src/app/_components/onboarding/create-team-form.tsx
@@ -35,6 +35,7 @@ export default function CreateTeamForm() {
 
   const createTeamMutation = trpc.team.create_team.useMutation({
     onSuccess: () => {
+      router.refresh();
       router.push(siteConfig.paths.onboarding, { scroll: false });
     },
     onError: (error) => {

--- a/src/app/_components/onboarding/join-team-form.tsx
+++ b/src/app/_components/onboarding/join-team-form.tsx
@@ -14,7 +14,10 @@ import { useForm } from "react-hook-form";
 import { Input } from "@/app/_components/ui/input";
 import { Button } from "@/app/_components/ui/button";
 import { Icons } from "@/app/_components/ui/icons";
-import { JoinTeamFormSchema, type TJoinTeamForm } from "@/app/_lib/zod-schemas/forms/onboarding/team";
+import {
+  JoinTeamFormSchema,
+  type TJoinTeamForm,
+} from "@/app/_lib/zod-schemas/forms/onboarding/team";
 import { trpc } from "@/app/_trpc/react";
 import { toast } from "../ui/use-toast";
 import { useRouter } from "next/navigation";
@@ -32,24 +35,25 @@ export default function JoinTeamForm() {
 
   const joinTeamMutation = trpc.team.join_team.useMutation({
     onSuccess: () => {
+      router.refresh();
       router.push(siteConfig.paths.onboarding, { scroll: false });
     },
     onError: (error) => {
       toast({
         description: error.message,
         variant: "destructive",
-        duration: 6000
-      })
-    }
-  })
+        duration: 6000,
+      });
+    },
+  });
 
   async function onSubmit(values: TJoinTeamForm) {
     try {
       const user = await getUser(supabase);
       await joinTeamMutation.mutateAsync({
         team_join_code: values.team_join_code,
-        user_uuid: user.id
-      })
+        user_uuid: user.id,
+      });
     } catch (err: unknown) {
       console.log(err);
       // TODO: Add Logger to capture browser api submission errors
@@ -58,7 +62,11 @@ export default function JoinTeamForm() {
 
   return (
     <Form {...form}>
-      <form id="joinTeamForm" className="space-y-8" onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        id="joinTeamForm"
+        className="space-y-8"
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
         <FormField
           control={form.control}
           name="team_join_code"
@@ -85,10 +93,10 @@ export default function JoinTeamForm() {
         <Button
           type="submit"
           className="w-full"
-          disabled={form.formState.isSubmitting || form.formState.isSubmitted}
+          disabled={form.formState.isSubmitting}
         >
           {form.formState.isSubmitting && (
-            <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />
+            <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
           )}
           Next
         </Button>

--- a/src/app/_components/onboarding/support-us-form.tsx
+++ b/src/app/_components/onboarding/support-us-form.tsx
@@ -3,13 +3,23 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
-import { SupportUsFormSchema, type TSupportUsForm } from "@/app/_lib/zod-schemas/forms/onboarding/support-us";
+import {
+  SupportUsFormSchema,
+  type TSupportUsForm,
+} from "@/app/_lib/zod-schemas/forms/onboarding/support-us";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { trpc } from "@/app/_trpc/react";
 import { siteConfig } from "@/app/_config/site";
 import { toast } from "../ui/use-toast";
 import { getUser } from "@/shared/supabase/auth";
-import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel } from "../ui/form";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "../ui/form";
 import { cn } from "@/app/_lib/client-utils";
 import NumberStepper from "./number-stepper";
 import { Switch } from "../ui/switch";
@@ -18,7 +28,10 @@ import { Icons } from "../ui/icons";
 
 type SupportUsFormProps = React.HTMLAttributes<HTMLDivElement>;
 
-export default function SupportUsForm({ className, ...props }: SupportUsFormProps) {
+export default function SupportUsForm({
+  className,
+  ...props
+}: SupportUsFormProps) {
   const router = useRouter();
   const supabase = createClientComponentClient();
 
@@ -26,22 +39,23 @@ export default function SupportUsForm({ className, ...props }: SupportUsFormProp
     resolver: zodResolver(SupportUsFormSchema),
     defaultValues: {
       user_support_administrative: false,
-      user_support_technical: false
-    }
+      user_support_technical: false,
+    },
   });
 
   const updateSupportUsMutation = trpc.user.update_support_us.useMutation({
     onSuccess: () => {
+      router.refresh();
       router.push(siteConfig.paths.onboarding, { scroll: false });
     },
     onError: (error) => {
       toast({
         description: error.message,
         variant: "destructive",
-        duration: 6000
+        duration: 6000,
       });
-    }
-  })
+    },
+  });
 
   async function onSubmit(values: TSupportUsForm) {
     try {
@@ -51,7 +65,7 @@ export default function SupportUsForm({ className, ...props }: SupportUsFormProp
         user_uuid: user.id,
         user_support_administrative: values.user_support_administrative,
         user_support_technical: values.user_support_technical,
-      })
+      });
     } catch (err: unknown) {
       console.log(err);
       // TODO: Add Logger to capture browser api submission errors
@@ -72,13 +86,12 @@ export default function SupportUsForm({ className, ...props }: SupportUsFormProp
               control={form.control}
               name="user_support_administrative"
               render={({ field }) => (
-                <FormItem className="flex flex-row items-center justify-between p-4 border rounded-lg">
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
                   <div className="space-y-0.5">
-                    <FormLabel className="text-base">
-                      Administrative
-                    </FormLabel>
+                    <FormLabel className="text-base">Administrative</FormLabel>
                     <FormDescription>
-                      Help us organize our social events, fundraising, and better our social media!
+                      Help us organize our social events, fundraising, and
+                      better our social media!
                     </FormDescription>
                   </div>
                   <FormControl>
@@ -95,11 +108,12 @@ export default function SupportUsForm({ className, ...props }: SupportUsFormProp
               control={form.control}
               name="user_support_technical"
               render={({ field }) => (
-                <FormItem className="flex flex-row items-center justify-between p-4 border rounded-lg">
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
                   <div className="space-y-0.5">
                     <FormLabel className="text-base">Technical</FormLabel>
                     <FormDescription>
-                      Help us innovate and develop hardware and software to further our unique experiences!
+                      Help us innovate and develop hardware and software to
+                      further our unique experiences!
                     </FormDescription>
                   </div>
                   <FormControl>
@@ -112,14 +126,18 @@ export default function SupportUsForm({ className, ...props }: SupportUsFormProp
               )}
             />
           </div>
-          <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={form.formState.isSubmitting}
+          >
             {form.formState.isSubmitting && (
-              <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />
+              <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
             )}
             Next
           </Button>
         </form>
       </Form>
-    </div >
+    </div>
   );
 }


### PR DESCRIPTION
# Description
There was a problem in redirecting users who tried to get past onboarding steps when using Codespaces. Submitting either the create/join team form would update the _user_onboarding_phase_ column in Supabase, but not redirect them. This may/may not be due to the behavior of the Tabs component provided by ShadCN which may share similar behavior to modals as discussed by this [issue](https://github.com/vercel/next.js/issues/51711). To deal with this for now, I:
- added `router.refresh()` to _create-team-form.tsx_
- added `router.refresh()` to _join-team-form.tsx_
- removed `form.formState.isSubmitted` button loading state condition from _join-team-form.tsx_
- added `router.refresh()` to _support-us.tsx_ (For some reason, this was required to redirect the user to the dashboard. Perhaps it has to do something with the behavior of the router refreshing.)

# Test Guidelines
1. Run project through codespaces.
2. Log in.
3. Attempt to fill out each onboarding step.