### PR TITLE
Editable/Deletable Announcements

### DIFF
--- a/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
+++ b/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
@@ -1,4 +1,4 @@
-import { EditAnnouncementPostForm } from "@/app/_components/forms/edit-announcement-post-form";
+import EditAnnouncementPostForm from "@/app/_components/forms/edit-announcement-post-form";
 import { serverTRPC } from "@/app/_trpc/server";
 import { type Metadata } from "next";
 

--- a/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
+++ b/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
@@ -1,0 +1,26 @@
+import { EditAnnouncementPostForm } from "@/app/_components/forms/edit-announcement-post-form";
+import { serverTRPC } from "@/app/_trpc/server";
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Edit Announcement | HackPSH",
+  description: "Edit an announcement.",
+};
+
+export default async function EditAnnouncementPage({
+  params,
+}: {
+  params: { postId: number };
+}) {
+  const postData = await serverTRPC.announcements.get_announcement_post.query({
+    //this is so cursed
+    announcement_id: parseInt(params.postId as unknown as string) as number,
+  });
+
+  return (
+    <div className="container my-8 max-w-4xl">
+      <h1 className="mb-6 text-2xl font-semibold">Edit Announcement</h1>
+      <EditAnnouncementPostForm postData={postData} />
+    </div>
+  );
+}

--- a/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
+++ b/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
@@ -1,7 +1,9 @@
 import EditAnnouncementPostForm from "@/app/_components/forms/edit-announcement-post-form";
 import { serverTRPC } from "@/app/_trpc/server";
+import { AnnouncementPost } from "@/server/dao/announcements";
 import { type Metadata } from "next";
 
+//fix types
 export const metadata: Metadata = {
   title: "Edit Announcement | HackPSH",
   description: "Edit an announcement.",
@@ -13,14 +15,15 @@ export default async function EditAnnouncementPage({
   params: { postId: number };
 }) {
   const postData = await serverTRPC.announcements.get_announcement_post.query({
-    //this is so cursed
     announcement_id: parseInt(params.postId as unknown as string) as number,
   });
 
   return (
     <div className="container my-8 max-w-4xl">
       <h1 className="mb-6 text-2xl font-semibold">Edit Announcement</h1>
-      <EditAnnouncementPostForm postData={postData} />
+      <EditAnnouncementPostForm
+        postData={postData as unknown as AnnouncementPost}
+      />
     </div>
   );
 }

--- a/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
+++ b/src/app/(main)/(routes)/(protected)/announcements/edit/[postId]/page.tsx
@@ -14,8 +14,9 @@ export default async function EditAnnouncementPage({
 }: {
   params: { postId: number };
 }) {
+  console.log(typeof params.postId);
   const postData = await serverTRPC.announcements.get_announcement_post.query({
-    announcement_id: parseInt(params.postId as unknown as string) as number,
+    announcement_id: parseInt(params.postId as unknown as string),
   });
 
   return (

--- a/src/app/_components/announcement/admin-create-post.tsx
+++ b/src/app/_components/announcement/admin-create-post.tsx
@@ -15,7 +15,7 @@ export default async function AdminCreatePostLink({
       user_uuid: user.id,
     });
 
-    if (get_user_role === "admin") {
+    if (get_user_role === "admin" || get_user_role === "officer") {
       return <AdminCreatePostButton />;
     }
   } catch (error) {

--- a/src/app/_components/announcement/announcement-post-actions-button.tsx
+++ b/src/app/_components/announcement/announcement-post-actions-button.tsx
@@ -15,7 +15,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { getUser } from "@/shared/supabase/auth";
 import { trpc } from "@/app/_trpc/react";
 
-export default function AnnouncementPostActions({
+export default function AnnouncementPostActionsButton({
   postID,
   className,
 }: {
@@ -81,8 +81,8 @@ export default function AnnouncementPostActions({
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="cursor-pointer"
-            onClick={() => {
-              deletePost(postID);
+            onClick={async () => {
+              await deletePost(postID);
             }}
           >
             <Trash className="mr-2 h-4 w-4" type="destructive" />

--- a/src/app/_components/announcement/announcement-post-actions-button.tsx
+++ b/src/app/_components/announcement/announcement-post-actions-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { Button } from "../ui/button";
+import { Ellipsis, Pencil, Trash } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { siteConfig } from "@/app/_config/site";
+
+//fix className declaration
+export default function AnnouncementPostActions({
+  postID,
+  className,
+}: {
+  postID: number;
+  className: string;
+}) {
+  const router = useRouter();
+
+  return (
+    <div className={className}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon">
+            <Ellipsis />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            onClick={() => {
+              router.push(siteConfig.paths.announcements + "/edit/" + postID);
+            }}
+            className="cursor-pointer"
+          >
+            <Pencil className="mr-2 h-4 w-4" />
+            <span>Edit</span>
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+          <DropdownMenuItem className="cursor-pointer">
+            <Trash className="mr-2 h-4 w-4" type="destructive" />
+            <span>Delete</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/app/_components/announcement/announcement-post-actions-button.tsx
+++ b/src/app/_components/announcement/announcement-post-actions-button.tsx
@@ -15,14 +15,12 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { getUser } from "@/shared/supabase/auth";
 import { trpc } from "@/app/_trpc/react";
 
-//fix className declaration
 export default function AnnouncementPostActions({
   postID,
   className,
 }: {
   postID: number;
-  className: string;
-}) {
+} & React.HTMLAttributes<HTMLDivElement>) {
   const router = useRouter();
 
   const announcementMutation =
@@ -47,8 +45,7 @@ export default function AnnouncementPostActions({
       },
     });
 
-  //CHANGE TYPE
-  async function deletePost(postID: any) {
+  async function deletePost(postID: number) {
     try {
       const supabase = createClientComponentClient();
       const user = await getUser(supabase);

--- a/src/app/_components/announcement/announcement-post-actions.tsx
+++ b/src/app/_components/announcement/announcement-post-actions.tsx
@@ -1,0 +1,29 @@
+import { serverTRPC } from "@/app/_trpc/server";
+import { composeServerComponentClient } from "@/server/lib/supabase/server";
+import { getUser } from "@/shared/supabase/auth";
+import AnnouncementPostActionsButton from "./announcement-post-actions-button";
+
+export default async function AnnouncementPostActions({
+  postID,
+}: {
+  postID: number;
+}) {
+  const supabase = composeServerComponentClient();
+  try {
+    const user = await getUser(supabase);
+    const { get_user_role } = await serverTRPC.user.get_user_role.query({
+      user_uuid: user.id,
+    });
+
+    if (get_user_role === "admin" || get_user_role === "officer") {
+      return (
+        <AnnouncementPostActionsButton
+          postID={postID}
+          className="absolute self-end"
+        />
+      );
+    }
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/src/app/_components/announcement/announcement-post-actions.tsx
+++ b/src/app/_components/announcement/announcement-post-actions.tsx
@@ -15,11 +15,11 @@ export default async function AnnouncementPostActions({
       user_uuid: user.id,
     });
 
-    if (get_user_role === "admin" || get_user_role === "officer") {
+    if (get_user_role !== "participant") {
       return (
         <AnnouncementPostActionsButton
           postID={postID}
-          className="absolute self-end"
+          className="absolute top-4 self-end"
         />
       );
     }

--- a/src/app/_components/announcement/announcement-post.tsx
+++ b/src/app/_components/announcement/announcement-post.tsx
@@ -8,9 +8,9 @@ import {
 } from "../ui/card";
 import AnnouncementPostActions from "./announcement-post-actions";
 
-interface AnnouncementPostProps {
+type AnnouncementPostProps = {
   postData: AnnouncementPost;
-}
+};
 
 export async function AnnouncementPost({ postData }: AnnouncementPostProps) {
   const {

--- a/src/app/_components/announcement/announcement-post.tsx
+++ b/src/app/_components/announcement/announcement-post.tsx
@@ -12,7 +12,7 @@ type AnnouncementPostProps = {
   postData: AnnouncementPost;
 };
 
-export async function AnnouncementPost({ postData }: AnnouncementPostProps) {
+export function AnnouncementPost({ postData }: AnnouncementPostProps) {
   const {
     announcement_uuid,
     announcement_created_at,

--- a/src/app/_components/announcement/announcement-post.tsx
+++ b/src/app/_components/announcement/announcement-post.tsx
@@ -6,18 +6,20 @@ import {
   CardDescription,
   CardContent,
 } from "../ui/card";
+import AnnouncementPostActions from "./announcement-post-actions";
 
 interface AnnouncementPostProps {
   postData: AnnouncementPost;
 }
 
-export function AnnouncementPost({ postData }: AnnouncementPostProps) {
+export async function AnnouncementPost({ postData }: AnnouncementPostProps) {
   const {
     announcement_uuid,
     announcement_created_at,
     announcement_author_display_name,
     announcement_title,
     announcement_content,
+    announcement_id,
   } = postData;
 
   const format_time_options: Intl.DateTimeFormatOptions = {
@@ -32,9 +34,10 @@ export function AnnouncementPost({ postData }: AnnouncementPostProps) {
     "en-US",
     format_time_options,
   ).format(announcement_created_at);
+
   return (
     <Card key={announcement_uuid} className="">
-      <CardHeader>
+      <CardHeader className="relative">
         <CardTitle>{announcement_title}</CardTitle>
         <CardDescription>
           <span className="font-semibold">Created By: </span>
@@ -43,6 +46,7 @@ export function AnnouncementPost({ postData }: AnnouncementPostProps) {
           <span className="font-semibold">Posted On: </span>
           {formatted_announcement_created_at}
         </CardDescription>
+        <AnnouncementPostActions postID={announcement_id} />
       </CardHeader>
       <CardContent>
         <p className="break-words">{announcement_content}</p>

--- a/src/app/_components/announcement/announcements.tsx
+++ b/src/app/_components/announcement/announcements.tsx
@@ -7,14 +7,14 @@ export async function Announcements() {
 
   const postElements: JSX.Element[] = [];
 
-  serverAnnouncementPosts.forEach((announcementPostData) =>
+  serverAnnouncementPosts.forEach((announcementPostData) => {
     postElements.push(
       <AnnouncementPost
         key={announcementPostData.announcement_uuid}
         postData={announcementPostData}
       />,
-    ),
-  );
+    );
+  });
 
   return <div className="space-y-4">{postElements}</div>;
 }

--- a/src/app/_components/forms/create-announcement-post-form.tsx
+++ b/src/app/_components/forms/create-announcement-post-form.tsx
@@ -41,7 +41,7 @@ export function CreateAnnouncementPostForm({
         toast({
           variant: "success",
           title: "Announcement Created!",
-          description: "Visit the announcements page to see your message.",
+          description: "You have successfully created an announcement.",
           duration: 4000,
         });
         router.replace("/announcements");

--- a/src/app/_components/forms/create-announcement-post-form.tsx
+++ b/src/app/_components/forms/create-announcement-post-form.tsx
@@ -68,7 +68,6 @@ export function CreateAnnouncementPostForm({
         title: values.title,
         content: values.content,
       });
-      form.reset();
     } catch (err: unknown) {
       console.log(err);
     }

--- a/src/app/_components/forms/edit-announcement-post-form.tsx
+++ b/src/app/_components/forms/edit-announcement-post-form.tsx
@@ -25,13 +25,21 @@ import { cn } from "@/app/_lib/client-utils";
 import { useRouter } from "next/navigation";
 
 type CreateAnouncementFormProps = React.HTMLAttributes<HTMLDivElement>;
+type EditAnnouncementFormProps = { postData: any }; //CHANGE
 
-export function CreateAnnouncementPostForm({
+export function EditAnnouncementPostForm({
+  postData,
   className,
   ...props
-}: CreateAnouncementFormProps) {
+}: CreateAnouncementFormProps & EditAnnouncementFormProps) {
+  const { announcement_title, announcement_content } = postData;
+
   const form = useForm<TCreateAnnouncementForm>({
     resolver: zodResolver(CreateAnnouncementFormSchema),
+    defaultValues: {
+      title: announcement_title,
+      content: announcement_content,
+    },
   });
   const router = useRouter();
 
@@ -122,7 +130,7 @@ export function CreateAnnouncementPostForm({
             {form.formState.isSubmitting && (
               <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
             )}
-            Post
+            Save
           </Button>
         </form>
       </Form>

--- a/src/app/_components/forms/edit-announcement-post-form.tsx
+++ b/src/app/_components/forms/edit-announcement-post-form.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { getUser } from "@/shared/supabase/auth";
 import {
   type TCreateAnnouncementForm,
   CreateAnnouncementFormSchema,
@@ -23,11 +22,13 @@ import { useForm } from "react-hook-form";
 import { Icons } from "../ui/icons";
 import { cn } from "@/app/_lib/client-utils";
 import { useRouter } from "next/navigation";
+import { getUser } from "@/shared/supabase/auth";
+// import { AnnouncementPost } from "@/server/dao/announcements";
 
 type CreateAnouncementFormProps = React.HTMLAttributes<HTMLDivElement>;
 type EditAnnouncementFormProps = { postData: any }; //CHANGE
 
-export function EditAnnouncementPostForm({
+export default function EditAnnouncementPostForm({
   postData,
   className,
   ...props
@@ -41,19 +42,24 @@ export function EditAnnouncementPostForm({
       content: announcement_content,
     },
   });
+
   const router = useRouter();
 
   const announcementMutation =
-    trpc.announcements.create_announcement_post.useMutation({
+    trpc.announcements.update_announcement_post.useMutation({
       onSuccess: () => {
         toast({
           variant: "success",
-          title: "Announcement Created!",
+          title: "Announcement Updated!",
           description: "Visit the announcements page to see your message.",
           duration: 4000,
         });
-        router.replace("/announcements");
+        form.reset({
+          title: "",
+          content: "",
+        });
         router.refresh();
+        router.back();
       },
       onError: () => {
         toast({
@@ -73,6 +79,7 @@ export function EditAnnouncementPostForm({
 
       await announcementMutation.mutateAsync({
         author_uuid: user.id,
+        announcement_id: postData.announcement_id,
         title: values.title,
         content: values.content,
       });
@@ -122,16 +129,27 @@ export function EditAnnouncementPostForm({
               </FormItem>
             )}
           />
-          <Button
-            type="submit"
-            className="ml-auto px-8"
-            disabled={form.formState.isSubmitting}
-          >
-            {form.formState.isSubmitting && (
-              <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-            )}
-            Save
-          </Button>
+          <div className="flex space-x-4">
+            <Button
+              type="button"
+              onClick={() => router.back()}
+              variant="navigation"
+              className="ml-auto px-8"
+              disabled={form.formState.isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="px-8"
+              disabled={form.formState.isSubmitting}
+            >
+              {form.formState.isSubmitting && (
+                <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Save
+            </Button>
+          </div>
         </form>
       </Form>
     </div>

--- a/src/app/_components/forms/edit-announcement-post-form.tsx
+++ b/src/app/_components/forms/edit-announcement-post-form.tsx
@@ -23,10 +23,10 @@ import { Icons } from "../ui/icons";
 import { cn } from "@/app/_lib/client-utils";
 import { useRouter } from "next/navigation";
 import { getUser } from "@/shared/supabase/auth";
-// import { AnnouncementPost } from "@/server/dao/announcements";
+import { AnnouncementPost } from "@/server/dao/announcements";
 
 type CreateAnouncementFormProps = React.HTMLAttributes<HTMLDivElement>;
-type EditAnnouncementFormProps = { postData: any }; //CHANGE
+type EditAnnouncementFormProps = { postData: AnnouncementPost }; //fix type
 
 export default function EditAnnouncementPostForm({
   postData,

--- a/src/app/_components/forms/edit-announcement-post-form.tsx
+++ b/src/app/_components/forms/edit-announcement-post-form.tsx
@@ -51,7 +51,7 @@ export default function EditAnnouncementPostForm({
         toast({
           variant: "success",
           title: "Announcement Updated!",
-          description: "Visit the announcements page to see your message.",
+          description: "You have successfully deleted an announcement.",
           duration: 4000,
         });
         form.reset({
@@ -78,7 +78,7 @@ export default function EditAnnouncementPostForm({
       const user = await getUser(supabase);
 
       await announcementMutation.mutateAsync({
-        author_uuid: user.id,
+        user_uuid: user.id,
         announcement_id: postData.announcement_id,
         title: values.title,
         content: values.content,

--- a/src/app/_config/site.ts
+++ b/src/app/_config/site.ts
@@ -29,6 +29,7 @@ export const siteConfig = {
     announcements: "/announcements",
     challenges: "/challenges",
     create_post: "/announcements/create-post",
+    edit_post: "/announcements/edit",
     privacy_policy: "/info/privacy-policy",
     terms_of_service: "/info/terms-of-service",
     settings: "/settings",

--- a/src/db/drizzle/0016_open_smiling_tiger.sql
+++ b/src/db/drizzle/0016_open_smiling_tiger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_schema"."app_announcement" ADD COLUMN "announcement_id" serial NOT NULL;

--- a/src/db/drizzle/meta/0016_snapshot.json
+++ b/src/db/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,494 @@
+{
+  "id": "9189eb34-f518-4539-bf9f-7b36df3b1449",
+  "prevId": "41b20e55-bc7a-4dd6-af48-da44082a3acc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app_schema.app_announcement": {
+      "name": "app_announcement",
+      "schema": "app_schema",
+      "columns": {
+        "announcement_uuid": {
+          "name": "announcement_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "announcement_created_at": {
+          "name": "announcement_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "announcement_author_uuid": {
+          "name": "announcement_author_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_title": {
+          "name": "announcement_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_content": {
+          "name": "announcement_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_announcement_announcement_author_uuid_app_user_profile_user_uuid_fk": {
+          "name": "app_announcement_announcement_author_uuid_app_user_profile_user_uuid_fk",
+          "tableFrom": "app_announcement",
+          "tableTo": "app_user_profile",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "announcement_author_uuid"
+          ],
+          "columnsTo": [
+            "user_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_contact": {
+      "name": "app_contact",
+      "schema": "app_schema",
+      "columns": {
+        "contact_uuid": {
+          "name": "contact_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "contact_created_at": {
+          "name": "contact_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_content": {
+          "name": "contact_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_major": {
+      "name": "app_major",
+      "schema": "app_schema",
+      "columns": {
+        "major_id": {
+          "name": "major_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "major_name": {
+          "name": "major_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_major_major_name_unique": {
+          "name": "app_major_major_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "major_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_onboarding_phase": {
+      "name": "app_onboarding_phase",
+      "schema": "app_schema",
+      "columns": {
+        "phase_id": {
+          "name": "phase_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase_name": {
+          "name": "phase_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_onboarding_phase_phase_name_unique": {
+          "name": "app_onboarding_phase_phase_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phase_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_role": {
+      "name": "app_role",
+      "schema": "app_schema",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_role_role_name_unique": {
+          "name": "app_role_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_school_year": {
+      "name": "app_school_year",
+      "schema": "app_schema",
+      "columns": {
+        "school_year_id": {
+          "name": "school_year_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "school_year_name": {
+          "name": "school_year_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_school_year_school_year_name_unique": {
+          "name": "app_school_year_school_year_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_year_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_team": {
+      "name": "app_team",
+      "schema": "app_schema",
+      "columns": {
+        "team_uuid": {
+          "name": "team_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_code": {
+          "name": "team_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_points": {
+          "name": "team_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_team_team_name_unique": {
+          "name": "app_team_team_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_name"
+          ]
+        },
+        "app_team_team_code_unique": {
+          "name": "app_team_team_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_code"
+          ]
+        }
+      }
+    },
+    "app_schema.app_user_profile": {
+      "name": "app_user_profile",
+      "schema": "app_schema",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_email_address": {
+          "name": "user_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_avatar_url": {
+          "name": "user_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_onboarding_complete": {
+          "name": "user_onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_display_name": {
+          "name": "user_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_resume_url": {
+          "name": "user_resume_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_team_uuid": {
+          "name": "user_team_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_school_year": {
+          "name": "user_school_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_major": {
+          "name": "user_major",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "user_support_administrative": {
+          "name": "user_support_administrative",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_support_technical": {
+          "name": "user_support_technical",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_onboarding_phase": {
+          "name": "user_onboarding_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal-details'"
+        }
+      },
+      "indexes": {
+        "user_uuid_index": {
+          "name": "user_uuid_index",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_profile_user_team_uuid_app_team_team_uuid_fk": {
+          "name": "app_user_profile_user_team_uuid_app_team_team_uuid_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_team",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_team_uuid"
+          ],
+          "columnsTo": [
+            "team_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_school_year_app_school_year_school_year_name_fk": {
+          "name": "app_user_profile_user_school_year_app_school_year_school_year_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_school_year",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_school_year"
+          ],
+          "columnsTo": [
+            "school_year_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_major_app_major_major_name_fk": {
+          "name": "app_user_profile_user_major_app_major_major_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_major",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_major"
+          ],
+          "columnsTo": [
+            "major_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_role_app_role_role_name_fk": {
+          "name": "app_user_profile_user_role_app_role_role_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_role",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_role"
+          ],
+          "columnsTo": [
+            "role_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_onboarding_phase_app_onboarding_phase_phase_name_fk": {
+          "name": "app_user_profile_user_onboarding_phase_app_onboarding_phase_phase_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_onboarding_phase",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_onboarding_phase"
+          ],
+          "columnsTo": [
+            "phase_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_user_profile_user_email_address_unique": {
+          "name": "app_user_profile_user_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_email_address"
+          ]
+        },
+        "app_user_profile_user_display_name_unique": {
+          "name": "app_user_profile_user_display_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_display_name"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app_schema": "app_schema"
+  },
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1726532134045,
       "tag": "0015_exotic_shiva",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1726870511130,
+      "tag": "0016_open_smiling_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/drizzle/schema.ts
+++ b/src/db/drizzle/schema.ts
@@ -80,6 +80,7 @@ export const app_announcement = app_schema.table("app_announcement", {
   announcement_author_uuid: uuid("announcement_author_uuid")
     .notNull()
     .references(() => app_user_profile.user_uuid),
+  announcement_id: serial("announcement_id"),
   announcement_title: text("announcement_title").notNull(),
   announcement_content: text("announcement_content").notNull(),
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,14 +39,8 @@ export async function middleware(req: NextRequest) {
     }
 
     if (
-      get_user_role === "participant" &&
-      req.nextUrl.pathname.startsWith(siteConfig.paths.create_post)
-    ) {
-      return redirectToPath(req, siteConfig.paths.announcements);
-    }
-
-    if (
-      get_user_role === "participant" &&
+      (get_user_role === "participant" &&
+        req.nextUrl.pathname.startsWith(siteConfig.paths.create_post)) ||
       req.nextUrl.pathname.startsWith(siteConfig.paths.edit_post)
     ) {
       return redirectToPath(req, siteConfig.paths.announcements);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,8 +39,15 @@ export async function middleware(req: NextRequest) {
     }
 
     if (
-      get_user_role !== "admin" &&
+      get_user_role === "participant" &&
       req.nextUrl.pathname.startsWith(siteConfig.paths.create_post)
+    ) {
+      return redirectToPath(req, siteConfig.paths.announcements);
+    }
+
+    if (
+      get_user_role === "participant" &&
+      req.nextUrl.pathname.startsWith(siteConfig.paths.edit_post)
     ) {
       return redirectToPath(req, siteConfig.paths.announcements);
     }

--- a/src/server/dao/announcements.ts
+++ b/src/server/dao/announcements.ts
@@ -60,6 +60,7 @@ export async function getAnnouncementPost(db: Database, id: number) {
       columns: {
         announcement_uuid: true,
         announcement_created_at: true,
+        announcement_author_uuid: true,
         announcement_title: true,
         announcement_content: true,
         announcement_id: true,

--- a/src/server/dao/announcements.ts
+++ b/src/server/dao/announcements.ts
@@ -12,6 +12,7 @@ export async function getAnnouncements(db: Database) {
         announcement_author_display_name: app_user_profile.user_display_name,
         announcement_title: app_announcement.announcement_title,
         announcement_content: app_announcement.announcement_content,
+        announcement_id: app_announcement.announcement_id,
       })
       .from(app_announcement)
       .innerJoin(
@@ -44,6 +45,28 @@ export async function createAnnouncementPost(
       announcement_content: content,
       announcement_title: title,
     });
+  } catch (error) {
+    throw new TRPCError({
+      message: "The database has encountered some issues.",
+      code: "INTERNAL_SERVER_ERROR",
+    });
+  }
+}
+
+export async function getAnnouncementPost(db: Database, id: number) {
+  try {
+    const announcement_post = await db.query.app_announcement.findFirst({
+      columns: {
+        announcement_uuid: true,
+        announcement_created_at: true,
+        announcement_title: true,
+        announcement_content: true,
+        announcement_id: true,
+      },
+      where: (post_data, { eq }) => eq(post_data.announcement_id, id),
+    });
+
+    return announcement_post;
   } catch (error) {
     throw new TRPCError({
       message: "The database has encountered some issues.",

--- a/src/server/dao/announcements.ts
+++ b/src/server/dao/announcements.ts
@@ -78,15 +78,15 @@ export async function getAnnouncementPost(db: Database, id: number) {
 
 export async function updateAnnouncementPost(
   db: Database,
-  author_uuid: string,
+  user_uuid: string,
   announcement_id: number,
   announcement_title: string,
   announcement_content: string,
 ) {
-  const result = await getUserRole(db, author_uuid);
+  const result = await getUserRole(db, user_uuid);
   if (result?.user_role === "participant") {
     throw new TRPCError({
-      message: "User must be an officer or admin to create announcements.",
+      message: "User must be an officer or admin to edit announcements.",
       code: "UNAUTHORIZED",
     });
   }
@@ -97,6 +97,28 @@ export async function updateAnnouncementPost(
       announcement_title,
       announcement_content,
     })
+    .where(eq(app_announcement.announcement_id, announcement_id));
+
+  return {
+    update_announcement_post: true,
+  };
+}
+
+export async function deleteAnnouncementPost(
+  db: Database,
+  user_uuid: string,
+  announcement_id: number,
+) {
+  const result = await getUserRole(db, user_uuid);
+  if (result?.user_role === "participant") {
+    throw new TRPCError({
+      message: "User must be an officer or admin to delete announcements.",
+      code: "UNAUTHORIZED",
+    });
+  }
+
+  await db
+    .delete(app_announcement)
     .where(eq(app_announcement.announcement_id, announcement_id));
 
   return {

--- a/src/server/procedures/protected/announcements/createAnnouncementPostProcedure.ts
+++ b/src/server/procedures/protected/announcements/createAnnouncementPostProcedure.ts
@@ -9,10 +9,10 @@ export default protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const user_data = await getUserRole(ctx.db, input.author_uuid);
 
-    if (user_data!.user_role !== "admin") {
+    if (user_data!.user_role === "participant") {
       throw new TRPCError({
         code: "UNAUTHORIZED",
-        message: "User must be an admin to create announcements.",
+        message: "User must be an officer or admin to create announcements.",
       });
     }
 

--- a/src/server/procedures/protected/announcements/deleteAnnouncementPostProcedure.ts
+++ b/src/server/procedures/protected/announcements/deleteAnnouncementPostProcedure.ts
@@ -1,16 +1,14 @@
-import { updateAnnouncementPost } from "@/server/dao/announcements";
+import { deleteAnnouncementPost } from "@/server/dao/announcements";
 import { protectedProcedure } from "@/server/trpc";
-import { UpdateAnnouncementPostSchema } from "@/server/zod-schemas/announcements";
+import { DeleteAnnouncementPostSchema } from "@/server/zod-schemas/announcements";
 
 export default protectedProcedure
-  .input(UpdateAnnouncementPostSchema)
+  .input(DeleteAnnouncementPostSchema)
   .mutation(async ({ ctx, input }) => {
-    await updateAnnouncementPost(
+    await deleteAnnouncementPost(
       ctx.db,
       input.user_uuid,
       input.announcement_id,
-      input.title,
-      input.content,
     );
 
     return {

--- a/src/server/procedures/protected/announcements/getAnnouncementPostProcedure.ts
+++ b/src/server/procedures/protected/announcements/getAnnouncementPostProcedure.ts
@@ -1,0 +1,11 @@
+import { getAnnouncementPost } from "@/server/dao/announcements";
+import { protectedProcedure } from "@/server/trpc";
+import { LookupAnnouncementPostSchema } from "@/server/zod-schemas/announcements";
+
+export default protectedProcedure
+  .input(LookupAnnouncementPostSchema)
+  .query(async ({ ctx, input }) => {
+    const result = await getAnnouncementPost(ctx.db, input.announcement_id);
+
+    return result;
+  });

--- a/src/server/procedures/protected/announcements/updateAnnouncementPostProcedure.ts
+++ b/src/server/procedures/protected/announcements/updateAnnouncementPostProcedure.ts
@@ -1,0 +1,19 @@
+import { updateAnnouncementPost } from "@/server/dao/announcements";
+import { protectedProcedure } from "@/server/trpc";
+import { UpdateAnnouncementPostSchema } from "@/server/zod-schemas/announcements";
+
+export default protectedProcedure
+  .input(UpdateAnnouncementPostSchema)
+  .mutation(async ({ ctx, input }) => {
+    await updateAnnouncementPost(
+      ctx.db,
+      input.author_uuid,
+      input.announcement_id,
+      input.title,
+      input.content,
+    );
+
+    return {
+      update_announcement_post: true,
+    };
+  });

--- a/src/server/routers/announcements.ts
+++ b/src/server/routers/announcements.ts
@@ -1,4 +1,5 @@
 import createAnnouncementPostProcedure from "../procedures/protected/announcements/createAnnouncementPostProcedure";
+import updateAnnouncementPostProcedure from "../procedures/protected/announcements/updateAnnouncementPostProcedure";
 import getAnnouncementPostProcedure from "../procedures/protected/announcements/getAnnouncementPostProcedure";
 import getAnnouncementsProcedure from "../procedures/protected/announcements/getAnnouncementsProcedure";
 import { createTRPCRouter } from "../trpc";
@@ -7,4 +8,5 @@ export const announcementsRouter = createTRPCRouter({
   get_announcement_posts: getAnnouncementsProcedure,
   create_announcement_post: createAnnouncementPostProcedure,
   get_announcement_post: getAnnouncementPostProcedure,
+  update_announcement_post: updateAnnouncementPostProcedure,
 });

--- a/src/server/routers/announcements.ts
+++ b/src/server/routers/announcements.ts
@@ -3,10 +3,12 @@ import updateAnnouncementPostProcedure from "../procedures/protected/announcemen
 import getAnnouncementPostProcedure from "../procedures/protected/announcements/getAnnouncementPostProcedure";
 import getAnnouncementsProcedure from "../procedures/protected/announcements/getAnnouncementsProcedure";
 import { createTRPCRouter } from "../trpc";
+import deleteAnnouncementPostProcedure from "../procedures/protected/announcements/deleteAnnouncementPostProcedure";
 
 export const announcementsRouter = createTRPCRouter({
   get_announcement_posts: getAnnouncementsProcedure,
   create_announcement_post: createAnnouncementPostProcedure,
   get_announcement_post: getAnnouncementPostProcedure,
   update_announcement_post: updateAnnouncementPostProcedure,
+  delete_announcement_post: deleteAnnouncementPostProcedure,
 });

--- a/src/server/routers/announcements.ts
+++ b/src/server/routers/announcements.ts
@@ -1,8 +1,10 @@
 import createAnnouncementPostProcedure from "../procedures/protected/announcements/createAnnouncementPostProcedure";
+import getAnnouncementPostProcedure from "../procedures/protected/announcements/getAnnouncementPostProcedure";
 import getAnnouncementsProcedure from "../procedures/protected/announcements/getAnnouncementsProcedure";
 import { createTRPCRouter } from "../trpc";
 
 export const announcementsRouter = createTRPCRouter({
   get_announcement_posts: getAnnouncementsProcedure,
   create_announcement_post: createAnnouncementPostProcedure,
+  get_announcement_post: getAnnouncementPostProcedure,
 });

--- a/src/server/zod-schemas/announcements.ts
+++ b/src/server/zod-schemas/announcements.ts
@@ -9,3 +9,10 @@ export const CreateAnnouncementPostSchema = z.object({
 export const LookupAnnouncementPostSchema = z.object({
   announcement_id: z.number(),
 });
+
+export const UpdateAnnouncementPostSchema = z.object({
+  author_uuid: z.string().uuid("Please provide a valid UUID."),
+  announcement_id: z.number(),
+  title: z.string().min(1, "Title must have at least a single character"),
+  content: z.string().min(1, "Content must at least have a single character"),
+});

--- a/src/server/zod-schemas/announcements.ts
+++ b/src/server/zod-schemas/announcements.ts
@@ -11,8 +11,13 @@ export const LookupAnnouncementPostSchema = z.object({
 });
 
 export const UpdateAnnouncementPostSchema = z.object({
-  author_uuid: z.string().uuid("Please provide a valid UUID."),
+  user_uuid: z.string().uuid("Please provide a valid UUID."),
   announcement_id: z.number(),
   title: z.string().min(1, "Title must have at least a single character"),
   content: z.string().min(1, "Content must at least have a single character"),
+});
+
+export const DeleteAnnouncementPostSchema = z.object({
+  user_uuid: z.string().uuid("Please provide a valid UUID."),
+  announcement_id: z.number(),
 });

--- a/src/server/zod-schemas/announcements.ts
+++ b/src/server/zod-schemas/announcements.ts
@@ -5,3 +5,7 @@ export const CreateAnnouncementPostSchema = z.object({
   title: z.string().min(1, "Title must have at least a single character"),
   content: z.string().min(1, "Content must at least have a single character"),
 });
+
+export const LookupAnnouncementPostSchema = z.object({
+  announcement_id: z.number(),
+});


### PR DESCRIPTION
# Description
Announcements can be edited or deleted by users with roles `admin` or `officer`. Previously, the lack of this feature meant the only way to modify announcements was to access the "app_announcement" table directly in Supabase. This change is important because it allows event administrators to keep announcements accurate and relevant. To achieve this, such changes were made:
- Added an auto-incrementing column to store a public ID
- Added dynamic routes based off that announcement ID
- Added procedures to use that ID to populate form title and content fields

# Test Guidelines
1. Log in
2. Set user role to `admin` or `officer` on Supabase
3. Click on announcement ellipsis
4. Edit/Delete post
