### PR TITLE
Support for More Languages + Improvements

### DIFF
--- a/src/app/_components/challenges/challenge-content.tsx
+++ b/src/app/_components/challenges/challenge-content.tsx
@@ -84,6 +84,7 @@ export default function ChallengeContentPage({
         userUUID={userUUID}
         setSolved={setSolved}
         setValue={setValue}
+        setLanguage={setLanguage}
       />
       <ProtectedEditorSiteHeader
         userDisplayName={userDisplayName}
@@ -121,6 +122,7 @@ export default function ChallengeContentPage({
             value={value}
             setValue={setValue}
             language={language}
+            setLanguage={setLanguage}
             header={presetHeader}
             solved={solved}
             userUUID={userUUID}
@@ -189,6 +191,6 @@ function getPresetHeader(header: string, language: TLanguages) {
   if (language === "python")
     return `# Implement this function\ndef ${header}:\n\t`;
   else if (language === "cpp")
-    return `// Implement this function\n${header}{\n\t\n}\n`;
+    return `#include <iostream>\n#include <vector>\n#include<string>\nusing namespace std;\n\n// Implement this function\n${header}{\n\t\n}\n`;
   else return `// Implement this function\nfunction ${header}{\n\t\n}\n`;
 }

--- a/src/app/_components/challenges/challenge-content.tsx
+++ b/src/app/_components/challenges/challenge-content.tsx
@@ -20,7 +20,6 @@ import ChallengeBooter from "./challenge-booter";
 import ChallengeSyncer from "./challenge-syncer";
 import { type TSubmitData } from "@/server/procedures/protected/challenges/submitCodeProcedure";
 import Link from "next/link";
-import { siteConfig } from "@/app/_config/site";
 
 export default function ChallengeContentPage({
   userDisplayName,
@@ -37,7 +36,9 @@ export default function ChallengeContentPage({
 }) {
   const [value, setValue] = useState("");
   const [outputData, setOutputData] = useState<TSubmitData | null>(null);
-  const [language, setLanguage] = useState<TLanguages>("python");
+  const [language, setLanguage] = useState<TLanguages>(
+    (localStorage.getItem("hackpsh-stored-language") as TLanguages) ?? "python",
+  );
   const [header, setHeader] = useState("");
   const [presetHeader, setPresetHeader] = useState("");
   const [solved, setSolved] = useState(false);

--- a/src/app/_components/challenges/challenge-editor.tsx
+++ b/src/app/_components/challenges/challenge-editor.tsx
@@ -13,6 +13,7 @@ import { trpc } from "@/app/_trpc/react";
 type ChallengeEditor = {
   value: string;
   setValue: Dispatch<SetStateAction<string>>;
+  setLanguage: Dispatch<SetStateAction<TLanguages>>;
   language: TLanguages;
   header: string;
   solved: boolean;
@@ -24,6 +25,7 @@ export default function ChallengeEditor({
   value,
   setValue,
   language,
+  setLanguage,
   header,
   solved,
   userUUID,
@@ -31,7 +33,7 @@ export default function ChallengeEditor({
 }: ChallengeEditor) {
   //update code submission only on initial render
   const [isFetched, setIsFetched] = useState<boolean>(false);
-  const { data: codeSubmission } = trpc.challenges.get_code_submission.useQuery(
+  const { data: submission } = trpc.challenges.get_code_submission.useQuery(
     {
       challenge_id: challengeId,
       user_uuid: userUUID,
@@ -39,12 +41,15 @@ export default function ChallengeEditor({
     { enabled: !isFetched },
   );
   useEffect(() => {
-    const submission = codeSubmission?.solved_challenge_code_submission;
     if (submission) {
-      setValue(submission);
+      const submissionCode = submission?.solved_challenge_code_submission;
+      const submissionLanguage =
+        submission?.solved_challenge_language as TLanguages;
+      setValue(submissionCode!);
+      setLanguage(submissionLanguage);
       setIsFetched(true);
     } else setValue(header);
-  }, [header, codeSubmission]);
+  }, [header, submission, setLanguage, language, setValue]);
 
   return (
     <div className={cn(solved && "cursor-not-allowed", "h-[320px]")}>
@@ -53,7 +58,7 @@ export default function ChallengeEditor({
         height="100%"
         theme="vs-dark"
         language={language}
-        defaultLanguage="python"
+        defaultLanguage={language ?? "python"}
         value={value}
         loading={""}
         onChange={(newValue) => setValue(newValue!)}

--- a/src/app/_components/challenges/challenge-editor.tsx
+++ b/src/app/_components/challenges/challenge-editor.tsx
@@ -30,7 +30,7 @@ export default function ChallengeEditor({
   challengeId,
 }: ChallengeEditor) {
   //update code submission only on initial render
-  const [isFetched, setIsFetched] = useState(false);
+  const [isFetched, setIsFetched] = useState<boolean>(false);
   const { data: codeSubmission } = trpc.challenges.get_code_submission.useQuery(
     {
       challenge_id: challengeId,
@@ -40,11 +40,11 @@ export default function ChallengeEditor({
   );
   useEffect(() => {
     const submission = codeSubmission?.solved_challenge_code_submission;
-    if (submission && !isFetched) {
+    if (submission) {
       setValue(submission);
       setIsFetched(true);
     } else setValue(header);
-  }, [header]);
+  }, [header, codeSubmission]);
 
   return (
     <div className={cn(solved && "cursor-not-allowed", "h-[320px]")}>

--- a/src/app/_components/challenges/challenge-nav-actions.tsx
+++ b/src/app/_components/challenges/challenge-nav-actions.tsx
@@ -14,7 +14,6 @@ import {
 import { Check, Edit, Play, Send } from "lucide-react";
 import { Skeleton } from "../ui/skeleton";
 import { type TLanguages } from "@/server/zod-schemas/challenges";
-import { useRouter } from "next/navigation";
 import { siteConfig } from "@/app/_config/site";
 import { type TSubmitData } from "@/server/procedures/protected/challenges/submitCodeProcedure";
 import Link from "next/link";
@@ -42,8 +41,6 @@ export default function ChallengeNavActions({
   setLanguage,
   setOutputData,
 }: ChallengeNavActionsProps) {
-  const router = useRouter();
-
   //runs code
   const { refetch: runCode, isFetching: isRunning } =
     trpc.challenges.run_code.useQuery(
@@ -54,6 +51,7 @@ export default function ChallengeNavActions({
         language: language,
       },
       {
+        retry: false,
         enabled: false,
         onSuccess: (outputData: TSubmitData) => {
           setOutputData(outputData);

--- a/src/app/_components/challenges/challenge-nav-actions.tsx
+++ b/src/app/_components/challenges/challenge-nav-actions.tsx
@@ -120,8 +120,9 @@ export default function ChallengeNavActions({
           <>
             <Select
               value={language}
-              onValueChange={(value: TLanguages) => {
-                setLanguage(value);
+              onValueChange={(language: TLanguages) => {
+                setLanguage(language);
+                localStorage.setItem("hackpsh-stored-language", language);
               }}
             >
               <SelectTrigger className="w-32">

--- a/src/app/_components/challenges/challenge-syncer.tsx
+++ b/src/app/_components/challenges/challenge-syncer.tsx
@@ -4,6 +4,7 @@ import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "../ui/use-toast";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { type TLanguages } from "@/server/zod-schemas/challenges";
 
 export default function ChallengeSyncer({
   challengeId,
@@ -12,6 +13,7 @@ export default function ChallengeSyncer({
   userUUID,
   setSolved,
   setValue,
+  setLanguage,
 }: {
   challengeId: number;
   challengePoints: number;
@@ -19,6 +21,7 @@ export default function ChallengeSyncer({
   userUUID: string;
   setSolved: Dispatch<SetStateAction<boolean>>;
   setValue: Dispatch<SetStateAction<string>>;
+  setLanguage: Dispatch<SetStateAction<TLanguages>>;
 }) {
   const router = useRouter();
   const supabase = createClientComponentClient();
@@ -64,9 +67,12 @@ export default function ChallengeSyncer({
             router.refresh();
           }
           const result = await getSubmission();
-          const submission = result.data?.solved_challenge_code_submission;
-          if (submission) {
-            setValue(submission);
+          const submissionCode = result.data?.solved_challenge_code_submission;
+          const submissionLanguage = result.data
+            ?.solved_challenge_language as TLanguages;
+          if (submissionCode && submissionLanguage) {
+            setValue(submissionCode);
+            setLanguage(submissionLanguage);
           }
         };
         void checkSolvedStatus();
@@ -78,7 +84,7 @@ export default function ChallengeSyncer({
     return () => {
       void supabase.removeChannel(channel);
     };
-  }, [checkSolved, router, setValue, teamName, challengeId, challengePoints]);
+  }, [checkSolved, setValue, setLanguage]);
 
   return <></>;
 }

--- a/src/app/_components/forms/create-challenge-form.tsx
+++ b/src/app/_components/forms/create-challenge-form.tsx
@@ -68,8 +68,8 @@ export function CreateChallengeForm({
         description: "You have successfully created a challenge.",
         duration: 4000,
       });
-      router.replace(siteConfig.paths.challenges);
       router.refresh();
+      router.back();
     },
     onError: (error) => {
       toast({
@@ -128,14 +128,6 @@ export function CreateChallengeForm({
   }
 
   function removeTestcase(i: number) {
-    // if (fields.length <= 2) {
-    //   toast({
-    //     variant: "destructive",
-    //     description: "Minimum of two test cases required.",
-    //     duration: 4000,
-    //   });
-    //   return;
-    // }
     remove(i);
   }
 

--- a/src/app/_components/forms/edit-challenge-form.tsx
+++ b/src/app/_components/forms/edit-challenge-form.tsx
@@ -89,6 +89,7 @@ export function EditChallengeForm({
         title: "Challenge updated.",
         duration: 4000,
       });
+      router.refresh();
       router.back();
     },
     onError: (error) => {
@@ -147,14 +148,6 @@ export function EditChallengeForm({
   }
 
   function removeTestcase(i: number) {
-    if (fields.length <= 2) {
-      toast({
-        variant: "destructive",
-        description: "Minimum of two test cases required.",
-        duration: 4000,
-      });
-      return;
-    }
     remove(i);
   }
 

--- a/src/db/drizzle/0001_stale_mongu.sql
+++ b/src/db/drizzle/0001_stale_mongu.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_schema"."app_solved_challenges" ADD COLUMN "solved_challenge_language" text NOT NULL;

--- a/src/db/drizzle/meta/0001_snapshot.json
+++ b/src/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,790 @@
+{
+  "id": "7b7a3ed7-8009-4df8-bc91-34b7cda4976d",
+  "prevId": "fd2a4fc8-044d-4274-84b8-5cf082c07162",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app_schema.app_announcement": {
+      "name": "app_announcement",
+      "schema": "app_schema",
+      "columns": {
+        "announcement_uuid": {
+          "name": "announcement_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "announcement_created_at": {
+          "name": "announcement_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "announcement_author_uuid": {
+          "name": "announcement_author_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_title": {
+          "name": "announcement_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_content": {
+          "name": "announcement_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_announcement_announcement_author_uuid_app_user_profile_user_uuid_fk": {
+          "name": "app_announcement_announcement_author_uuid_app_user_profile_user_uuid_fk",
+          "tableFrom": "app_announcement",
+          "tableTo": "app_user_profile",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "announcement_author_uuid"
+          ],
+          "columnsTo": [
+            "user_uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_challenges": {
+      "name": "app_challenges",
+      "schema": "app_schema",
+      "columns": {
+        "challenge_uuid": {
+          "name": "challenge_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_title": {
+          "name": "challenge_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_difficulty": {
+          "name": "challenge_difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_points": {
+          "name": "challenge_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "challenge_description": {
+          "name": "challenge_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_function_header": {
+          "name": "challenge_function_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_example_input": {
+          "name": "challenge_example_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_example_output": {
+          "name": "challenge_example_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_explanation": {
+          "name": "challenge_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_challenges_challenge_difficulty_app_difficulty_difficulty_name_fk": {
+          "name": "app_challenges_challenge_difficulty_app_difficulty_difficulty_name_fk",
+          "tableFrom": "app_challenges",
+          "tableTo": "app_difficulty",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "challenge_difficulty"
+          ],
+          "columnsTo": [
+            "difficulty_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_contact": {
+      "name": "app_contact",
+      "schema": "app_schema",
+      "columns": {
+        "contact_uuid": {
+          "name": "contact_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "contact_created_at": {
+          "name": "contact_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_content": {
+          "name": "contact_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_difficulty": {
+      "name": "app_difficulty",
+      "schema": "app_schema",
+      "columns": {
+        "difficulty_id": {
+          "name": "difficulty_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "difficulty_name": {
+          "name": "difficulty_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_difficulty_difficulty_name_unique": {
+          "name": "app_difficulty_difficulty_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "difficulty_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_event": {
+      "name": "app_event",
+      "schema": "app_schema",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_start_time": {
+          "name": "event_start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_end_time": {
+          "name": "event_end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_start_hour": {
+          "name": "event_start_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_duration": {
+          "name": "event_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_challenges_enabled": {
+          "name": "event_challenges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_major": {
+      "name": "app_major",
+      "schema": "app_schema",
+      "columns": {
+        "major_id": {
+          "name": "major_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "major_name": {
+          "name": "major_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_major_major_name_unique": {
+          "name": "app_major_major_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "major_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_onboarding_phase": {
+      "name": "app_onboarding_phase",
+      "schema": "app_schema",
+      "columns": {
+        "phase_id": {
+          "name": "phase_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase_name": {
+          "name": "phase_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_onboarding_phase_phase_name_unique": {
+          "name": "app_onboarding_phase_phase_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phase_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_role": {
+      "name": "app_role",
+      "schema": "app_schema",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_role_role_name_unique": {
+          "name": "app_role_role_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_school_year": {
+      "name": "app_school_year",
+      "schema": "app_schema",
+      "columns": {
+        "school_year_id": {
+          "name": "school_year_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "school_year_name": {
+          "name": "school_year_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_school_year_school_year_name_unique": {
+          "name": "app_school_year_school_year_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "school_year_name"
+          ]
+        }
+      }
+    },
+    "app_schema.app_solved_challenges": {
+      "name": "app_solved_challenges",
+      "schema": "app_schema",
+      "columns": {
+        "solved_challenge_uuid": {
+          "name": "solved_challenge_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "solved_challenge_foreign_uuid": {
+          "name": "solved_challenge_foreign_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solved_challenge_team_uuid": {
+          "name": "solved_challenge_team_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solved_challenge_code_submission": {
+          "name": "solved_challenge_code_submission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solved_challenge_language": {
+          "name": "solved_challenge_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_solved_challenges_solved_challenge_foreign_uuid_app_challenges_challenge_uuid_fk": {
+          "name": "app_solved_challenges_solved_challenge_foreign_uuid_app_challenges_challenge_uuid_fk",
+          "tableFrom": "app_solved_challenges",
+          "tableTo": "app_challenges",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "solved_challenge_foreign_uuid"
+          ],
+          "columnsTo": [
+            "challenge_uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_solved_challenges_solved_challenge_team_uuid_app_team_team_uuid_fk": {
+          "name": "app_solved_challenges_solved_challenge_team_uuid_app_team_team_uuid_fk",
+          "tableFrom": "app_solved_challenges",
+          "tableTo": "app_team",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "solved_challenge_team_uuid"
+          ],
+          "columnsTo": [
+            "team_uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_team": {
+      "name": "app_team",
+      "schema": "app_schema",
+      "columns": {
+        "team_uuid": {
+          "name": "team_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_code": {
+          "name": "team_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_points": {
+          "name": "team_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "team_points_additive": {
+          "name": "team_points_additive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_team_team_name_unique": {
+          "name": "app_team_team_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_name"
+          ]
+        },
+        "app_team_team_code_unique": {
+          "name": "app_team_team_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_code"
+          ]
+        }
+      }
+    },
+    "app_schema.app_test_cases": {
+      "name": "app_test_cases",
+      "schema": "app_schema",
+      "columns": {
+        "test_case_uuid": {
+          "name": "test_case_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "test_case_input": {
+          "name": "test_case_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_output": {
+          "name": "test_case_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_challenge_uuid": {
+          "name": "test_case_challenge_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_test_cases_test_case_challenge_uuid_app_challenges_challenge_uuid_fk": {
+          "name": "app_test_cases_test_case_challenge_uuid_app_challenges_challenge_uuid_fk",
+          "tableFrom": "app_test_cases",
+          "tableTo": "app_challenges",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "test_case_challenge_uuid"
+          ],
+          "columnsTo": [
+            "challenge_uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_schema.app_user_profile": {
+      "name": "app_user_profile",
+      "schema": "app_schema",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_email_address": {
+          "name": "user_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_avatar_url": {
+          "name": "user_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_onboarding_complete": {
+          "name": "user_onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_display_name": {
+          "name": "user_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_resume_url": {
+          "name": "user_resume_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_team_uuid": {
+          "name": "user_team_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_school_year": {
+          "name": "user_school_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_major": {
+          "name": "user_major",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "user_support_administrative": {
+          "name": "user_support_administrative",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_support_technical": {
+          "name": "user_support_technical",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_onboarding_phase": {
+          "name": "user_onboarding_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal-details'"
+        }
+      },
+      "indexes": {
+        "user_uuid_index": {
+          "name": "user_uuid_index",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_profile_user_team_uuid_app_team_team_uuid_fk": {
+          "name": "app_user_profile_user_team_uuid_app_team_team_uuid_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_team",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_team_uuid"
+          ],
+          "columnsTo": [
+            "team_uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_school_year_app_school_year_school_year_name_fk": {
+          "name": "app_user_profile_user_school_year_app_school_year_school_year_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_school_year",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_school_year"
+          ],
+          "columnsTo": [
+            "school_year_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_major_app_major_major_name_fk": {
+          "name": "app_user_profile_user_major_app_major_major_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_major",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_major"
+          ],
+          "columnsTo": [
+            "major_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_role_app_role_role_name_fk": {
+          "name": "app_user_profile_user_role_app_role_role_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_role",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_role"
+          ],
+          "columnsTo": [
+            "role_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_profile_user_onboarding_phase_app_onboarding_phase_phase_name_fk": {
+          "name": "app_user_profile_user_onboarding_phase_app_onboarding_phase_phase_name_fk",
+          "tableFrom": "app_user_profile",
+          "tableTo": "app_onboarding_phase",
+          "schemaTo": "app_schema",
+          "columnsFrom": [
+            "user_onboarding_phase"
+          ],
+          "columnsTo": [
+            "phase_name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_user_profile_user_email_address_unique": {
+          "name": "app_user_profile_user_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_email_address"
+          ]
+        },
+        "app_user_profile_user_display_name_unique": {
+          "name": "app_user_profile_user_display_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_display_name"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app_schema": "app_schema"
+  },
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1728898846272,
       "tag": "0000_curved_leopardon",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1729147476774,
+      "tag": "0001_stale_mongu",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/drizzle/schema.ts
+++ b/src/db/drizzle/schema.ts
@@ -160,4 +160,5 @@ export const app_solved_challenges = app_schema.table("app_solved_challenges", {
     .references(() => app_team.team_uuid, { onDelete: "cascade" })
     .notNull(),
   solved_challenge_code_submission: text("solved_challenge_code_submission"),
+  solved_challenge_language: text("solved_challenge_language").notNull(),
 });

--- a/src/server/dao/challenges.ts
+++ b/src/server/dao/challenges.ts
@@ -386,6 +386,21 @@ export async function updateChallenge(
   }
 
   try {
+    //delete old test cases with new ones; easier for test case deletions
+    const matchingChallenge = await db.query.app_challenges.findFirst({
+      where: eq(app_challenges.challenge_id, challengeId),
+    });
+
+    await db
+      .delete(app_test_cases)
+      .where(
+        eq(
+          app_test_cases.test_case_challenge_uuid,
+          matchingChallenge!.challenge_uuid,
+        ),
+      );
+
+    //update challenge info
     const challenge = await db
       .update(app_challenges)
       .set({
@@ -403,14 +418,13 @@ export async function updateChallenge(
 
     const challengeUUID = challenge[0]!.uuid;
 
+    //insert test cases
     for (const test_case of test_cases) {
-      await db
-        .update(app_test_cases)
-        .set({
-          test_case_input: test_case.input,
-          test_case_output: test_case.output,
-        })
-        .where(eq(app_test_cases.test_case_challenge_uuid, challengeUUID));
+      await db.insert(app_test_cases).values({
+        test_case_input: test_case.input,
+        test_case_output: test_case.output,
+        test_case_challenge_uuid: challengeUUID,
+      });
     }
   } catch (error) {
     throw new TRPCError({

--- a/src/server/dao/challenges.ts
+++ b/src/server/dao/challenges.ts
@@ -207,6 +207,7 @@ export async function getCodeSubmission(
       const result = db.query.app_solved_challenges.findFirst({
         columns: {
           solved_challenge_code_submission: true,
+          solved_challenge_language: true,
         },
         where: and(
           eq(
@@ -424,6 +425,7 @@ export async function solveChallenge(
   challenge_id: number,
   user_uuid: string,
   code_submission: string,
+  language: string,
 ) {
   try {
     const challenge = await db.query.app_challenges.findFirst({
@@ -463,6 +465,7 @@ export async function solveChallenge(
         solved_challenge_foreign_uuid: challenge!.challenge_uuid,
         solved_challenge_team_uuid: teamUUID!.user_team_uuid!,
         solved_challenge_code_submission: code_submission,
+        solved_challenge_language: language,
       });
 
       await db


### PR DESCRIPTION
# Description
Added **challenge support for C++ and Javascript**. This is definitely still in testing, but I am planning to merge this since it is a working feature. The difficult part will be running multiple test cases against C++ since syntax differs greatly from Python and Javascript.

Also **fixed challenge updates** by replacing test cases with new ones. Before, the db would only update existing test cases, but not deal with test case deletions. Now, test cases are completely replaced with new ones for every challenge update. Although this approach makes database queries, it simplifies the logic between deleting old test cases given the available columns for the `app_test_cases` table.

Also **stored the current language into localStorage** so users don't have to constantly change their language to their preference upon each challenge page load. This is retrieved on initial render and set on language select.